### PR TITLE
Edit some text so that be more senseful.

### DIFF
--- a/cips/cip-1.md
+++ b/cips/cip-1.md
@@ -1,9 +1,9 @@
 ---
 cip: 1
 title: Celestia Improvement Proposal Process and Guidelines
+author: Yaz Khoury <yaz@celestia.org>
 status: Draft
 type: Meta
-author: Yaz Khoury <yaz@celestia.org>
 created: 2023-04-13
 ---
 
@@ -259,7 +259,7 @@ the following parts:
 
 * **Preamble**: RFC 822 style headers containing metadata about the CIP,
   including the CIP number, a short descriptive title (limited to a maximum
-  of 44 characters), a description (limited to a maximum of 140 characters),
+  of 44 words), a description (limited to a maximum of 140 words),
   and the author details. Regardless of the category, the title and description
   should not include the CIP number. See below for details.
 * **Abstract**: A multi-sentence (short paragraph) technical summary that
@@ -290,7 +290,8 @@ the following parts:
   This section can be omitted for non-Core proposals.
 * **Reference Implementation (optional)**: This optional section contains
   a reference/example implementation that people can use to better understand
-  or implement the specification. This section can be omitted for all CIPs.
+  or implement the specification. This section can be omitted for all CIPs (
+  mandatory for Core CIPs to reach the Final stage).
 * **Security Considerations**: All CIPs must include a section discussing
   relevant security implications and considerations. This section should
   provide information critical for security discussions, expose risks, and


### PR DESCRIPTION
1. Because even the title of this cip is longer than 44 chars, I believe the unit of limit should be 'words'.

2. Adding a reference for relative rules could make it more senseful.

3. Do not need these rules that conflict with this cip itself.


Besides these modifications, after more thinking, I feel the Cip-1 should not be so complex. Just like the U.S. Constitution which has only rationale, rights, responsibility, and reference, but not the details of type, process, format, header, and editor. I believe these should be in separated cips because they could be changed more frequently.