### PR TITLE
CIP: Packet Forward Middleware

### DIFF
--- a/cips/cip-PFM.md
+++ b/cips/cip-PFM.md
@@ -216,11 +216,9 @@ packet amount if the fee percentage is non-zero.
 
 ## Security Considerations
 
-All CIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. For example, include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. CIP submissions missing the "Security Considerations" section will be rejected. An CIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.
-
-The current placeholder is acceptable for a draft.
-
-**TODO: Remove the previous comments before submitting**
+The origin sender (sender on the first chain) is retained in case of a failure to receive the packet (max-timeouts or ack error) on any chain in the sequence, so funds will be refunded to the right sender in the case of an error.
+Any intermediate receivers, though, are not used anymore. PFM will receive the funds into the hashed account (hash of sender from previous chain + channel received on the current chain). This gives a deterministic account for the origin sender to see events on intermediate chains. With PFM's atomic acks (examples on README), there is no possibility of funds getting stuck on an intermediate chain, they will either make it to the final destination successfully, or be refunded back to the origin sender.
+Then, as a bonus, we can recommend that users set the intermediate receivers to a string such as "pfm" (since PFM does not care what the intermediate receiver is), so that in case users accidentally send a packet intended for PFM to a chain that does not have PFM, they will get an ack error and refund instead of funds landing in the intermediate receiver account. I.e it gives us a PFM detection mechanism with a graceful error.
 
 ## Copyright
 

--- a/cips/cip-PFM.md
+++ b/cips/cip-PFM.md
@@ -34,16 +34,6 @@ The defaults set in Packet Forward Middleware ensure sensible timeouts so user f
 
 *"No backward compatibility issues found."*
 
-## Test Cases
-
-This section is optional.
-
-The Test Cases section should include expected input/output pairs, but may include a succinct set of executable tests. It should not include project build files. No new requirements may be be introduced here (meaning an implementation following only the Specification section should pass all tests here.)
-
-If the test suite is too large to reasonably be included inline, then consider adding it as one or more files in `../assets/cip-####/`. External links will not be allowed
-
-**TODO: Remove the previous comments before submitting**
-
 ## Reference Implementation
 
 The integration steps include the following:
@@ -169,7 +159,7 @@ Here is an example of how to create an application stack using `transfer` and `p
 The following `transferStack` is configured in `app/app.go` and added to the IBC `Router`. 
 The in-line comments describe the execution flow of packets between the application stack and IBC core.
 
-For more information on configuring an IBC application stack see the ibc-go docs [here](https://github.com/cosmos/ibc-go/blob/main/docs/middleware/ics29-fee/integration.md#configuring-an-application-stack-with-fee-middleware).
+For more information on configuring an IBC application stack see the ibc-go docs
 
 
 ```go

--- a/cips/cip-PFM.md
+++ b/cips/cip-PFM.md
@@ -53,7 +53,7 @@ The integration steps include the following:
 
 Integration of the PFM should take approximately 20 minutes.
 
-# Example integration of the Packet Forward Middleware
+### Example integration of the Packet Forward Middleware
 
 ```go
 // app.go
@@ -163,7 +163,7 @@ func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino
 }
 ```
 
-# Configuring the transfer application stack with Packet Forward Middleware
+### Configuring the transfer application stack with Packet Forward Middleware
 
 Here is an example of how to create an application stack using `transfer` and `packet-forward-middleware`. 
 The following `transferStack` is configured in `app/app.go` and added to the IBC `Router`. 
@@ -197,7 +197,7 @@ transferStack = packetforward.NewIBCMiddleware(
 ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack)
 ```
 
-# Configurable options in the Packet Forward Middleware
+### Configurable options in the Packet Forward Middleware
 
 The Packet Forward Middleware has several configurable options available when initializing the IBC application stack. 
 You can see these passed in as arguments to `packetforward.NewIBCMiddleware` and they include the number of retries that

--- a/cips/cip-PFM.md
+++ b/cips/cip-PFM.md
@@ -207,8 +207,10 @@ packet amount if the fee percentage is non-zero.
 ## Security Considerations
 
 The origin sender (sender on the first chain) is retained in case of a failure to receive the packet (max-timeouts or ack error) on any chain in the sequence, so funds will be refunded to the right sender in the case of an error.
-Any intermediate receivers, though, are not used anymore. PFM will receive the funds into the hashed account (hash of sender from previous chain + channel received on the current chain). This gives a deterministic account for the origin sender to see events on intermediate chains. With PFM's atomic acks (examples on README), there is no possibility of funds getting stuck on an intermediate chain, they will either make it to the final destination successfully, or be refunded back to the origin sender.
-Then, as a bonus, we can recommend that users set the intermediate receivers to a string such as "pfm" (since PFM does not care what the intermediate receiver is), so that in case users accidentally send a packet intended for PFM to a chain that does not have PFM, they will get an ack error and refund instead of funds landing in the intermediate receiver account. I.e it gives us a PFM detection mechanism with a graceful error.
+
+Any intermediate receivers, though, are not used anymore. PFM will receive the funds into the hashed account (hash of sender from previous chain + channel received on the current chain). This gives a deterministic account for the origin sender to see events on intermediate chains. With PFM's atomic acks, there is no possibility of funds getting stuck on an intermediate chain, they will either make it to the final destination successfully, or be refunded back to the origin sender.
+
+We recommend that users set the intermediate receivers to a string such as "pfm" (since PFM does not care what the intermediate receiver is), so that in case users accidentally send a packet intended for PFM to a chain that does not have PFM, they will get an ack error and refunded instead of funds landing in the intermediate receiver account. This results in a PFM detection mechanism with a graceful error.
 
 ## Copyright
 

--- a/cips/cip-PFM.md
+++ b/cips/cip-PFM.md
@@ -24,11 +24,11 @@ This CIP integrates Packet Forward Middleware, the IBC middleware that enables m
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-Celestia MUST import and integrate Packet Forward Middleware. This integration SHOULD use sensible defaults for the following configs: [Retries On Timeout, Timeout Period, Refund Timeout, Fee Percentage].
+Celestia MUST import and integrate Packet Forward Middleware. This integration SHOULD use defaults for the following configs: [Retries On Timeout, Timeout Period, Refund Timeout, Fee Percentage]. Celestia MAY choose different values for these configs if the community would rather have auto-retries, different timeout periods, and/or collect fees from forwarded packets.
 
 ## Rationale
 
-**TODO: What are the recommended defaults?**
+The defaults set in Packet Forward Middleware ensure sensible timeouts so user funds are returned in a timely manner after incomplete transfers. Timeout follows IBC defaults and Refund Timeout is 28 days to ensure funds don't remain stuck in the packet forward module. Retries On Timeout is defaulted to 0, as app developers or cli users may want to control this themselves. Fee Percentage is defaulted to 0 for superior user experience; however, the Celestia community may decide to collect fees as a revenue source.
 
 ## Backwards Compatibility
 

--- a/cips/cip-PFM.md
+++ b/cips/cip-PFM.md
@@ -18,19 +18,7 @@ This is the suggested template for new CIPs. After you have filled in the requis
 
 ## Abstract
 
-The Abstract is a multi-sentence (short paragraph) technical summary. This should be a very terse and human-readable version of the specification section. Someone should be able to read only the abstract to get the gist of what this specification does.
-
-**TODO: Remove the previous comments before submitting**
-
-## Motivation
-
-This section is optional.
-
-The motivation section should include a description of any nontrivial problems the CIP solves. It should not describe how the CIP solves those problems, unless it is not immediately obvious. It should not describe why the CIP should be made into a standard, unless it is not immediately obvious.
-
-With a few exceptions, external links are not allowed. If you feel that a particular resource would demonstrate a compelling case for your CIP, then save it as a printer-friendly PDF, put it in the assets folder, and link to that copy.
-
-**TODO: Remove the previous comments before submitting**
+This CIP integrates Packet Forward Middleware, the IBC middleware that enables multi-hop IBC and path unwinding to preserve fungibility for IBC-transferred tokens.
 
 ## Specification
 
@@ -42,7 +30,11 @@ It is recommended to follow RFC 2119 and RFC 8170. Do not remove the key word de
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
+Celestia MUST import and integrate Packet Forward Middleware. This integration SHOULD use sensible defaults for the following configs: [Retries On Timeout, Timeout Period, Refund Timeout, Fee Percentage].
+
 ## Rationale
+
+**TODO: What are the recommended defaults?**
 
 The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages.
 

--- a/cips/cip-PFM.md
+++ b/cips/cip-PFM.md
@@ -22,12 +22,6 @@ This CIP integrates Packet Forward Middleware, the IBC middleware that enables m
 
 ## Specification
 
-The Specification section should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Celestia clients (celestia-node, celestia-core, celestia-app).
-
-It is recommended to follow RFC 2119 and RFC 8170. Do not remove the key word definitions if RFC 2119 and RFC 8170 are followed.
-
-**TODO: Remove the previous comments before submitting**
-
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
 Celestia MUST import and integrate Packet Forward Middleware. This integration SHOULD use sensible defaults for the following configs: [Retries On Timeout, Timeout Period, Refund Timeout, Fee Percentage].
@@ -36,21 +30,9 @@ Celestia MUST import and integrate Packet Forward Middleware. This integration S
 
 **TODO: What are the recommended defaults?**
 
-The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages.
-
-The current placeholder is acceptable for a draft.
-
-**TODO: Remove the previous comments before submitting**
-
 ## Backwards Compatibility
 
-This section is optional.
-
-All CIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The CIP must explain how the author proposes to deal with these incompatibilities. CIP submissions without a sufficient backwards compatibility treatise may be rejected outright.
-
-The current placeholder is acceptable for a draft: *"No backward compatibility issues found."*
-
-**TODO: Remove the previous comments before submitting**
+*"No backward compatibility issues found."*
 
 ## Test Cases
 
@@ -64,13 +46,173 @@ If the test suite is too large to reasonably be included inline, then consider a
 
 ## Reference Implementation
 
-This section is optional.
+The integration steps include the following:
+1. Import the PFM, initialize the PFM Module & Keeper, initialize the store keys and module params, and initialize the Begin/End Block logic and InitGenesis order.
+2. Configure the IBC application stack including the transfer module.
+3. Configuration of additional options such as timeout period, number of retries on timeout, refund timeout period, and fee percentage.
 
-The Reference Implementation section should include a minimal implementation that assists in understanding or implementing this specification. It should not include project build files. The reference implementation is not a replacement for the Specification section, and the proposal should still be understandable without it.
+Integration of the PFM should take approximately 20 minutes.
 
-If the reference implementation is too large to reasonably be included inline, then consider adding it as one or more files in `../assets/cip-####/`. External links will not be allowed.
+# Example integration of the Packet Forward Middleware
 
-**TODO: Remove the previous comments before submitting**
+```go
+// app.go
+
+// Import the packet forward middleware
+import (
+    "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/packetforward"
+    packetforwardkeeper "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/packetforward/keeper"
+    packetforwardtypes "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/packetforward/types"
+)
+
+...
+
+// Register the AppModule for the packet forward middleware module
+ModuleBasics = module.NewBasicManager(
+    ...
+    packetforward.AppModuleBasic{},
+    ...
+)
+
+...
+
+// Add packet forward middleware Keeper
+type App struct {
+	...
+	PacketForwardKeeper *packetforwardkeeper.Keeper
+	...
+}
+
+...
+
+// Create store keys 
+keys := sdk.NewKVStoreKeys(
+    ...
+    packetforwardtypes.StoreKey,
+    ...
+)
+
+...
+
+// Initialize the packet forward middleware Keeper
+// It's important to note that the PFM Keeper must be initialized before the Transfer Keeper
+app.PacketForwardKeeper = packetforwardkeeper.NewKeeper(
+    appCodec,
+    keys[packetforwardtypes.StoreKey],
+    app.GetSubspace(packetforwardtypes.ModuleName),
+    app.TransferKeeper, // will be zero-value here, reference is set later on with SetTransferKeeper.
+    app.IBCKeeper.ChannelKeeper,
+    appKeepers.DistrKeeper,
+    app.BankKeeper,
+    app.IBCKeeper.ChannelKeeper,
+)
+
+// Initialize the transfer module Keeper
+app.TransferKeeper = ibctransferkeeper.NewKeeper(
+    appCodec,
+    keys[ibctransfertypes.StoreKey],
+    app.GetSubspace(ibctransfertypes.ModuleName),
+    app.PacketForwardKeeper,
+    app.IBCKeeper.ChannelKeeper,
+    &app.IBCKeeper.PortKeeper,
+    app.AccountKeeper,
+    app.BankKeeper,
+    scopedTransferKeeper,
+)
+
+app.PacketForwardKeeper.SetTransferKeeper(app.TransferKeeper)
+
+// See the section below for configuring an application stack with the packet forward middleware 
+
+...
+
+// Register packet forward middleware AppModule
+app.moduleManager = module.NewManager(
+    ...
+    packetforward.NewAppModule(app.PacketForwardKeeper),
+)
+
+...
+
+// Add packet forward middleware to begin blocker logic
+app.moduleManager.SetOrderBeginBlockers(
+    ...
+    packetforwardtypes.ModuleName,
+    ...
+)
+
+// Add packet forward middleware to end blocker logic
+app.moduleManager.SetOrderEndBlockers(
+    ...
+    packetforwardtypes.ModuleName,
+    ...
+)
+
+// Add packet forward middleware to init genesis logic
+app.moduleManager.SetOrderInitGenesis(
+    ...
+    packetforwardtypes.ModuleName,
+    ...
+)
+
+// Add packet forward middleware to init params keeper
+func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino, key, tkey storetypes.StoreKey) paramskeeper.Keeper {
+    ...
+    paramsKeeper.Subspace(packetforwardtypes.ModuleName).WithKeyTable(packetforwardtypes.ParamKeyTable())
+    ...
+}
+```
+
+# Configuring the transfer application stack with Packet Forward Middleware
+
+Here is an example of how to create an application stack using `transfer` and `packet-forward-middleware`. 
+The following `transferStack` is configured in `app/app.go` and added to the IBC `Router`. 
+The in-line comments describe the execution flow of packets between the application stack and IBC core.
+
+For more information on configuring an IBC application stack see the ibc-go docs [here](https://github.com/cosmos/ibc-go/blob/main/docs/middleware/ics29-fee/integration.md#configuring-an-application-stack-with-fee-middleware).
+
+
+```go
+// Create Transfer Stack
+// SendPacket, since it is originating from the application to core IBC:
+// transferKeeper.SendPacket -> packetforward.SendPacket -> channel.SendPacket
+
+// RecvPacket, message that originates from core IBC and goes down to app, the flow is the other way
+// channel.RecvPacket -> packetforward.OnRecvPacket -> transfer.OnRecvPacket
+
+// transfer stack contains (from top to bottom):
+// - Packet Forward Middleware
+// - Transfer
+var transferStack ibcporttypes.IBCModule
+transferStack = transfer.NewIBCModule(app.TransferKeeper)
+transferStack = packetforward.NewIBCMiddleware(
+	transferStack,
+	app.PacketForwardKeeper,
+	0, // retries on timeout
+	packetforwardkeeper.DefaultForwardTransferPacketTimeoutTimestamp, // forward timeout
+	packetforwardkeeper.DefaultRefundTransferPacketTimeoutTimestamp, // refund timeout
+)
+
+// Add transfer stack to IBC Router
+ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack)
+```
+
+# Configurable options in the Packet Forward Middleware
+
+The Packet Forward Middleware has several configurable options available when initializing the IBC application stack. 
+You can see these passed in as arguments to `packetforward.NewIBCMiddleware` and they include the number of retries that
+will be performed on a forward timeout, the timeout period that will be used for a forward, and the timeout period that
+will be used for performing refunds in the case that a forward is taking too long.
+
+Additionally, there is a fee percentage parameter that can be set in `InitGenesis`, this is an optional parameter that
+can be used to take a fee from each forwarded packet which will then be distributed to the community pool. In the 
+`OnRecvPacket` callback `ForwardTransferPacket` is invoked which will attempt to subtract a fee from the forwarded
+packet amount if the fee percentage is non-zero.
+
+- Retries On Timeout - how many times will a forward be re-attempted in the case of a timeout.
+- Timeout Period - how long can a forward be in progress before giving up.
+- Refund Timeout - how long can a forward be in progress before issuing a refund back to the original source chain.
+- Fee Percentage - % of the forwarded packet amount which will be subtracted and distributed to the community pool.
 
 ## Security Considerations
 

--- a/cips/cip-PFM.md
+++ b/cips/cip-PFM.md
@@ -10,12 +10,6 @@ created: Date created on, in ISO 8601 (yyyy-mm-dd) format
 ---
 <!-- markdownlint-disable MD013 -->
 
-> Note:
-**READ CIP-1 BEFORE USING THIS TEMPLATE!**
-This is the suggested template for new CIPs. After you have filled in the requisite fields, please delete these comments. Note that an CIP number will be assigned by an editor. When opening a pull request to submit your CIP, please use an abbreviated title in the filename, `cip-draft_title_abbrev.md`. The title should be 44 characters or less. It should not repeat the CIP number in title, irrespective of the category.
-
-**TODO: Remove the note before submitting**
-
 ## Abstract
 
 This CIP integrates Packet Forward Middleware, the IBC middleware that enables multi-hop IBC and path unwinding to preserve fungibility for IBC-transferred tokens.

--- a/cips/cip-PFM.md
+++ b/cips/cip-PFM.md
@@ -1,0 +1,94 @@
+---
+title: Packet Forward Middleware
+description: Adopt Packet Forward Middleware for multi-hop IBC and path unwinding
+author: Alex Cheng (@akc2267)
+discussions-to: URL
+status: Draft
+type: Standards Track
+category: Core
+created: Date created on, in ISO 8601 (yyyy-mm-dd) format
+---
+<!-- markdownlint-disable MD013 -->
+
+> Note:
+**READ CIP-1 BEFORE USING THIS TEMPLATE!**
+This is the suggested template for new CIPs. After you have filled in the requisite fields, please delete these comments. Note that an CIP number will be assigned by an editor. When opening a pull request to submit your CIP, please use an abbreviated title in the filename, `cip-draft_title_abbrev.md`. The title should be 44 characters or less. It should not repeat the CIP number in title, irrespective of the category.
+
+**TODO: Remove the note before submitting**
+
+## Abstract
+
+The Abstract is a multi-sentence (short paragraph) technical summary. This should be a very terse and human-readable version of the specification section. Someone should be able to read only the abstract to get the gist of what this specification does.
+
+**TODO: Remove the previous comments before submitting**
+
+## Motivation
+
+This section is optional.
+
+The motivation section should include a description of any nontrivial problems the CIP solves. It should not describe how the CIP solves those problems, unless it is not immediately obvious. It should not describe why the CIP should be made into a standard, unless it is not immediately obvious.
+
+With a few exceptions, external links are not allowed. If you feel that a particular resource would demonstrate a compelling case for your CIP, then save it as a printer-friendly PDF, put it in the assets folder, and link to that copy.
+
+**TODO: Remove the previous comments before submitting**
+
+## Specification
+
+The Specification section should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Celestia clients (celestia-node, celestia-core, celestia-app).
+
+It is recommended to follow RFC 2119 and RFC 8170. Do not remove the key word definitions if RFC 2119 and RFC 8170 are followed.
+
+**TODO: Remove the previous comments before submitting**
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+## Rationale
+
+The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages.
+
+The current placeholder is acceptable for a draft.
+
+**TODO: Remove the previous comments before submitting**
+
+## Backwards Compatibility
+
+This section is optional.
+
+All CIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The CIP must explain how the author proposes to deal with these incompatibilities. CIP submissions without a sufficient backwards compatibility treatise may be rejected outright.
+
+The current placeholder is acceptable for a draft: *"No backward compatibility issues found."*
+
+**TODO: Remove the previous comments before submitting**
+
+## Test Cases
+
+This section is optional.
+
+The Test Cases section should include expected input/output pairs, but may include a succinct set of executable tests. It should not include project build files. No new requirements may be be introduced here (meaning an implementation following only the Specification section should pass all tests here.)
+
+If the test suite is too large to reasonably be included inline, then consider adding it as one or more files in `../assets/cip-####/`. External links will not be allowed
+
+**TODO: Remove the previous comments before submitting**
+
+## Reference Implementation
+
+This section is optional.
+
+The Reference Implementation section should include a minimal implementation that assists in understanding or implementing this specification. It should not include project build files. The reference implementation is not a replacement for the Specification section, and the proposal should still be understandable without it.
+
+If the reference implementation is too large to reasonably be included inline, then consider adding it as one or more files in `../assets/cip-####/`. External links will not be allowed.
+
+**TODO: Remove the previous comments before submitting**
+
+## Security Considerations
+
+All CIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. For example, include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. CIP submissions missing the "Security Considerations" section will be rejected. An CIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.
+
+The current placeholder is acceptable for a draft.
+
+**TODO: Remove the previous comments before submitting**
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE).
+<!-- markdownlint-disable MD013 -->


### PR DESCRIPTION
## Overview

This PR introduces a new CIP for integrating Packet Forward Middleware (PFM).

PFM is an IBC middleware module that enables multi-hop IBC and path unwinding. Incorporating PFM will allow Celestia to route incoming IBC packets from a source chain to a destination chain.

## Checklist

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
