### PR TITLE
chore(cip-11): add withdrawal reason

### DIFF
--- a/cips/cip-11.md
+++ b/cips/cip-11.md
@@ -5,6 +5,7 @@ description: Refund allocated but unspent gas to the transaction fee payer.
 author: Rootul Patel (@rootulp)
 discussions-to: https://forum.celestia.org/t/cip-refund-unspent-gas/1374
 status: Withdrawn
+withdrawal-reason: The mitigation strategies for the security considerations were deemed too complex.
 type: Standards Track
 category: Core
 created: 2023-12-07


### PR DESCRIPTION
## Motivation

> I see this CIP was withdrawn. I think that means it should be updated with a withdrawal-reason, per [CIPs/cips/cip-1.md at main · celestiaorg/CIPs · GitHub](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-1.md#cip-header-preamble) ?

See https://forum.celestia.org/t/cip-refund-unspent-gas/1374/2