### PR TITLE
Update cip-6.md title and add summary table

### DIFF
--- a/cips/cip-6.md
+++ b/cips/cip-6.md
@@ -16,7 +16,7 @@ Implement a global, consensus-enforced minimum gas price on all transactions. En
 
 | Parameter     | Default | Summary                                                                                                                | Changeable via Governance |
 |---------------|---------|------------------------------------------------------------------------------------------------------------------------|---------------------------|
-| gas.MinimumGasPrice | 0.002utia  | Globally set minimum price per unit of gas                                                            | True                     |
+| minfee.MinimumGasPrice | 0.002utia  | Globally set minimum price per unit of gas                                                            | True                     |
 
 ## Motivation
 

--- a/cips/cip-6.md
+++ b/cips/cip-6.md
@@ -1,6 +1,6 @@
 ---
 cip: 6
-title: Price enforcement
+title: Mininum gas price enforcement
 description: Enforce payment of the gas for a transaction based on a governance modifiable global minimum gas price 
 author: Callum Waters (@cmwaters)
 discussions-to: https://forum.celestia.org/t/cip-006-price-enforcement/1351
@@ -14,13 +14,17 @@ created: 2023-11-30
 
 Implement a global, consensus-enforced minimum gas price on all transactions. Ensure that all transactions can be decoded and have a valid signer with sufficient balance to cover the cost of the gas allocated in the transaction. The minimum gas price can be modified via on-chain governance.
 
+| Parameter     | Default | Summary                                                                                                                | Changeable via Governance |
+|---------------|---------|------------------------------------------------------------------------------------------------------------------------|---------------------------|
+| gas.MinimumGasPrice | 0.002utia  | Globally set minimum price per unit of gas                                                            | True                     |
+
 ## Motivation
 
 The Celestia network was launched with the focus on having all the necessary protocols in place to provide secure data availability first and to focus on building an effective fee market system that correctly captures that value afterwards.
 
 This is not to say that no fee market system exists. Celestia inherited the default system provided by the Cosmos SDK. However, the present system has several inadequacies that need to be addressed in order to achieve better pricing certainty and transaction guarantees for it’s users and to find a “fair” price for both the sellers (validators) and buyers (rollups) of data availability.
 
-This proposal should be viewed as a foundational component of a more broader effort and thus it’s scope is strictly focused towards the enforcement of some minimum fee: **ensuring that the value captured goes to those that provided that value**. It does not pertain to actual pricing mechanisms, tipping, refunds, futures and other possible future works. Dynamic systems like EIP-1559 and uniform price auctions can and should be prioritised only once the network starts to experience congestion over block space.
+This proposal should be viewed as a foundational component of a broader effort and thus its scope is strictly focused towards the enforcement of some minimum fee: **ensuring that the value captured goes to those that provided that value**. It does not pertain to actual pricing mechanisms, tipping, refunds, futures and other possible future works. Dynamic systems like EIP-1559 and uniform price auctions can and should be prioritised only once the network starts to experience congestion over block space.
 
 ## Specification
 


### PR DESCRIPTION
In the spirit of CIP-13, added a single-row table summarizing the new parameter.

Would be good to set a standard to have this table in any CIP that introduces a new parameter or modifies one so it can easily be copied into CIP-13 if/when it's approved.

In this vein it wasn't entirely clear to me what the param store will be called. This CIP mentions it will be a new param.Subspace but doesn't name it, so I'm optimistically calling it `gas` but feel free to correct. That said it's not clear to me why this shouldn't just go under `auth` along with eg. `auth.TxSizeCostPerByte`? 

Also updated the title to be a bit more descriptive

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
