### PR TITLE
feat: update lemongrass hardfork to remove CIP 12 relayer incentivized middleware

### DIFF
--- a/cips/cip-17.md
+++ b/cips/cip-17.md
@@ -7,7 +7,7 @@ discussions-to: https://forum.celestia.org/t/lemongrass-hardfork/1589
 status: Draft
 type: Meta
 created: 2024-02-16
-requires: CIP-6, CIP-9, CIP-10, CIP-12, CIP-14
+requires: CIP-6, CIP-9, CIP-10, CIP-14
 ---
 
 ## Abstract
@@ -21,7 +21,6 @@ This Meta CIP lists the CIPs included in the Lemongrass network upgrade.
 - [CIP-10](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-10.md): Coordinated Upgrades
 - [CIP-14](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-14.md): Interchain Accounts
 - [CIP-9](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-9.md): Packet Forward Middleware
-- [CIP-12](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-12.md): Incentivization middleware ICS-29
 - [CIP-6](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-6.md): Price Enforcement
 
 All of the above CIPs are state breaking, and thus require a hardfork. The activation of this hardfork will be different from future hardforks, as described in [CIP-10](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-10.md).


### PR DESCRIPTION
## Overview

This is a brief update the remove a CIP from the lemongrass upgrade. This still needs discussion before merging.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
