### PR TITLE
cip-19!: breaking Shwap protocol improvements

### DIFF
--- a/cips/cip-19.md
+++ b/cips/cip-19.md
@@ -367,7 +367,7 @@ expected to be bigger. Also, it is more efficient to parallelize EDS requesting 
 
 #### Blocks
 
-Bitswap operates over IPFS blocks(not to mix with Celestia or other blockchain blocks). An IPFS block is a blob of
+Bitswap operates over IPFS blocks (not to mix with Celestia or other blockchain blocks). An IPFS block is a blob of
 arbitrary bytes addressed and identified with a [CID](#multihashes-and-cids). An IPFS block must have a CID encoded into
 it, s.t. the CID can either be computed by hashing the block or by extracting it out of the block data itself.
 

--- a/cips/cip-19.md
+++ b/cips/cip-19.md
@@ -258,55 +258,56 @@ and be verified against the respective root from the Row or Column axis in [DAH]
 
 **ProofType**: An enum defining which axis root the Proof is coming from. It MUST be either RowProofType or ColumnProofType.
 
-#### DataID
+#### RowNamespaceDataID
 
-DataID identifies [namespace][ns] Data container of shares within a _single_ Row. That is, namespace shares spanning
+RowNamespaceDataID identifies [namespace][ns] Data container of shares within a _single_ Row. That is, namespace shares spanning
 over multiple Rows are identified with multiple identifiers.
 
-DataID identifiers are formatted as shown below:
+RowNamespaceDataID identifiers are formatted as shown below:
 
 ```text
-DataID {
+RowNamespaceDataID {
     RowID;
     Namespace;
 }
 ```
 
-The fields with validity rules that form DataID are:
+The fields with validity rules that form RowNamespaceDataID are:
 
 [**RowID**](#rowid): A RowID of the namespace data. It MUST follow [RowID](#rowid) formatting and field validity rules.
 
 [**Namespace**][ns]: A fixed-size 29 bytes array representing the Namespace of interest. It MUST follow [Namespace][ns]
 formatting and its validity rules.
 
-[Serialized](#serialization-for-share-identifiers) DataID MUST have a length of 39 bytes.
+[Serialized](#serialization-for-share-identifiers) RowNamespaceDataID MUST have a length of 39 bytes.
 
-#### Data Container
+#### RowNamespaceData Container
 
-Data containers encapsulate user-submitted data under [namespaces][ns].
+RowNamespaceData containers encapsulate user-submitted data under [namespaces][ns] within a single [DataSquare][square]
+row.
 
-Data containers are protobuf formatted using the following proto3 schema:
+RowNamespaceData containers are protobuf formatted using the following proto3 schema:
 
 ```protobuf
 syntax = "proto3";
 
-message Data {
-    repeated bytes data_shares = 1;
-    Proof data_proof = 2;
+message RowNamespaceData {
+    repeated bytes rnd_shares = 1;
+    Proof rnd_proof = 2;
 }
 ```
 
 The fields with validity rules that form Data containers are:
 
-**DataShares**: A two-dimensional variable size byte array representing left data shares of a namespace in the row.
+**RNDShares**: A two-dimensional variable size byte array representing left data shares of a namespace in the row.
 Each share MUST follow [share formatting and validity][shares-format] rules.
 
-**DataProof**: A [protobuf formated][nmt-pb] [NMT][nmt] proof of share inclusion. It MUST follow [NMT proof verification][nmt-verify]
+**RNDProof**: A [protobuf formated][nmt-pb] [NMT][nmt] proof of share inclusion. It MUST follow [NMT proof verification][nmt-verify]
 and be verified against the respective root from the Row root axis in [DAH][dah].
 
-Namespace data may span over multiple rows, in which case all the data is encapsulated in multiple containers. This
-enables parallelization of namespace data retrieval and certain [compositions](#protocol-compositions) may get advantage
-of that by requesting containers of a single namespace from multiple servers simultaneously.
+Namespace data may span over multiple rows, in which case all the data is encapsulated in multiple RowNamespaceData
+containers. This enables parallelization of namespace data retrieval and certain [compositions](#protocol-compositions)
+may get advantage of that by requesting containers of a single namespace from multiple servers simultaneously.
 
 ## Protocol Compositions
 
@@ -354,12 +355,12 @@ Bitswap still requires multihashes and CID codecs to be registered. Therefore, w
 required [share identifiers](#share-identifiers) with their respective multihash and CID codec codes. This table
 should be extended whenever any new share identifier or new version of an existing identifier is added.
 
-| Name     | Multihash | Codec  |
-|----------|-----------|--------|
-| EdsID*   | N/A       | N/A    |
-| RowID    | 0x7801    | 0x7800 |
-| SampleID | 0x7811    | 0x7810 |
-| DataID   | 0x7821    | 0x7820 |
+| Name               | Multihash | Codec  |
+|--------------------|-----------|--------|
+| EdsID*             | N/A       | N/A    |
+| RowID              | 0x7801    | 0x7800 |
+| SampleID           | 0x7811    | 0x7810 |
+| RowNamespaceDataID | 0x7821    | 0x7820 |
 
 *EdsID and container are excluded from Bitswap composition. Bitswap is limited to messages of size 256kb, while EDSes are
 expected to be bigger. Also, it is more efficient to parallelize EDS requesting by rows.
@@ -414,24 +415,24 @@ formatting and field validity rules.
 [**Sample**](#sample-container): An imported Sample container protobuf message. It MUST follow [Sample](#sample-container)
 formatting and field validity rules.
 
-##### DataBlock
+##### RowNamespaceDataBlock
 
 ```protobuf
 syntax = "proto3";
 
-message DataBlock {
-    repeated bytes data_id = 1;
-    Data data = 2;
+message RowNamespaceDataBlock {
+    repeated bytes rnd_id = 1;
+    RowNamespaceData rnd = 2;
 }
 ```
 
-The fields with validity rules that form DataBlock are:
+The fields with validity rules that form RowNamespaceDataBlock are:
 
-[**DataID**](#dataid): A DataID of the [Data Container](#data-container). It MUST follow [DataID](#dataid) formatting
-and field validity rules.
+[**RowNamespaceDataID**](#rownamespacedataid): A RowNamespaceDataID of the [RowNamespaceData Container](#rownamespacedata-container).
+It MUST follow [RowNamespaceDataID](#rownamespacedataid) formatting and field validity rules.
 
-[**Data**](#data-container): An imported Data container protobuf message. It MUST follow [Data](#data-container)
-formatting and field validity rules.
+[**RowNamespaceData**](#rownamespacedata-container): An imported RowNamespaceData container protobuf message. It MUST
+follow [RowNamespaceData](#rownamespacedata-container) formatting and field validity rules.
 
 ## Backwards Compatibility
 

--- a/cips/cip-19.md
+++ b/cips/cip-19.md
@@ -5,7 +5,6 @@ description: Shwap - a new messaging framework for DA and sampling
 author: Hlib Kanunnikov (@Wondertan)
 discussions-to: https://forum.celestia.org/t/cip-shwap-protocol/1551
 status: Review
-last-call-deadline: 2024-04-17
 type: Standards Track
 category: Data Availability, Networking
 created: 2024-02-02

--- a/cips/cip-19.md
+++ b/cips/cip-19.md
@@ -4,7 +4,7 @@ title: Shwap Protocol
 description: Shwap - a new messaging framework for DA and sampling
 author: Hlib Kanunnikov (@Wondertan)
 discussions-to: https://forum.celestia.org/t/cip-shwap-protocol/1551
-status: Last Call
+status: Review
 last-call-deadline: 2024-04-17
 type: Standards Track
 category: Data Availability, Networking


### PR DESCRIPTION
## Decouple IDs out of Containers
This is a protocol-breaking change for Shwap. Initially, containers kept the identifiers as a first field in them. However, we decided to decouple those.

The Bitswap protocol dictates the requirement to have IDs in containers and this enforces certain limitations and overhead for the core Shwap containers. However, we want to use the containers outside of the Bitswap composition context, and thus, we need to remove this requirement from the containers. Furthermore, we design Shwap in a protocol-agnostic way, and Bitswap enforcing limits on containers is inconsistent with that. 

As Bitswap still _requires_ coupling between data and identifiers, we introduce container adapters for the Bitswap composition to address that.

## Rename `Data` container and ID
We rename `Data` -> `RowNamespaceData` and increase verbosity to improve clarity around the meaning of the type. Prefixing `Row` and `Namespace` narrows down the scope of the very general `Data`. Altogether, `RowNamespaceData` specifies that its data of a specific namespace in a specific row. This opens up space for future containers like `NamespaceData` which is data of a specific namespace, but over multiple rows.

## Add `IsParity` field to `Row` container
This allows the server to choose which half of the row to serve. In special cases, this saves erasure coding computation for the server, while the client side has to do this computation anyway to verify the served data. For example, the server may store only the left (non-parity) or right (parity) side of the row.