### PR TITLE
chore: remove RIM from Lemongrass

### DIFF
--- a/cips/cip-17.md
+++ b/cips/cip-17.md
@@ -7,7 +7,7 @@ discussions-to: https://forum.celestia.org/t/lemongrass-hardfork/1589
 status: Draft
 type: Meta
 created: 2024-02-16
-requires: CIP-6, CIP-9, CIP-10, CIP-12, CIP-14
+requires: CIP-6, CIP-9, CIP-10, CIP-14, CIP-20
 ---
 
 ## Abstract
@@ -21,7 +21,6 @@ This Meta CIP lists the CIPs included in the Lemongrass network upgrade.
 - [CIP-6](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-6.md): Price Enforcement
 - [CIP-9](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-9.md): Packet Forward Middleware
 - [CIP-10](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-10.md): Coordinated Upgrades
-- [CIP-12](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-12.md): Incentivization middleware ICS-29
 - [CIP-14](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-14.md): Interchain Accounts
 - [CIP-20](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-20.md): Disable Blobstream module
 


### PR DESCRIPTION
## Motivation

My impression from today's call is that we're not including CIP-12 (Relayer Incentivization Middleware) in Lemongrass.