### PR TITLE
docs(cip-14): move to last call

### DIFF
--- a/cips/cip-14.md
+++ b/cips/cip-14.md
@@ -4,7 +4,8 @@ title: ICS-27 Interchain Accounts
 description: Adding ICS-27 Interchain Accounts to Celestia to enable cross-chain account management
 author:  Susannah Evans <susannah@interchain.io> (@womensrights), Aidan Salzmann <aidan@stridelabs.co> (@asalzmann), Sam Pochyly <sam@stridelabs.co> (@sampocs)
 discussions-to: https://forum.celestia.org/t/moving-toward-safer-and-more-aligned-tia-liquid-staking/1422
-status: Review
+status: Last Call
+last-call-deadline: 2024-05-07
 type: Standards Track
 category: Core
 created: 2023-01-04


### PR DESCRIPTION
CIP-14 hasn't had any significant changes recently. Same for the relevant [forum post](https://forum.celestia.org/t/moving-toward-safer-and-more-aligned-tia-liquid-staking/1422).

I propose moving it to last call with a deadline two weeks from now.
