### PR TITLE
docs(cip-17): remove price enforcement

### DIFF
--- a/cips/cip-17.md
+++ b/cips/cip-17.md
@@ -7,7 +7,7 @@ discussions-to: https://forum.celestia.org/t/lemongrass-hardfork/1589
 status: Draft
 type: Meta
 created: 2024-02-16
-requires: CIP-6, CIP-9, CIP-10, CIP-14, CIP-20
+requires: CIP-9, CIP-10, CIP-14, CIP-20
 ---
 
 ## Abstract
@@ -18,7 +18,6 @@ This Meta CIP lists the CIPs included in the Lemongrass network upgrade.
 
 ### Included CIPs
 
-- [CIP-6](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-6.md): Price Enforcement
 - [CIP-9](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-9.md): Packet Forward Middleware
 - [CIP-10](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-10.md): Coordinated Upgrades
 - [CIP-14](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-14.md): Interchain Accounts


### PR DESCRIPTION
Remove price enforcement ([CIP-6](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-6.md)) from the list of included CIPs in the Lemongrass hard-fork. We recently decided that this feature needs to be tweaked before it provides significant value so we're withdrawing it from inclusion in the Lemongrass hard-fork but CIP-6 may be considered for future hard-forks.