### PR TITLE
docs: update status CIP-6, CIP-10, CIP-14

### DIFF
--- a/cips/cip-10.md
+++ b/cips/cip-10.md
@@ -4,8 +4,7 @@ title: Coordinated network upgrades
 description: Protocol for coordinating major network upgrades
 author: Callum Waters (@cmwaters)
 discussions-to: https://forum.celestia.org/t/cip-coordinated-network-upgrades/1367
-status: Last Call
-last-call-deadline: 2024-05-07
+status: Final
 type: Standards Track
 category: Core
 created: 2023-12-7

--- a/cips/cip-14.md
+++ b/cips/cip-14.md
@@ -4,8 +4,7 @@ title: ICS-27 Interchain Accounts
 description: Adding ICS-27 Interchain Accounts to Celestia to enable cross-chain account management
 author:  Susannah Evans <susannah@interchain.io> (@womensrights), Aidan Salzmann <aidan@stridelabs.co> (@asalzmann), Sam Pochyly <sam@stridelabs.co> (@sampocs)
 discussions-to: https://forum.celestia.org/t/moving-toward-safer-and-more-aligned-tia-liquid-staking/1422
-status: Last Call
-last-call-deadline: 2024-05-07
+status: Final
 type: Standards Track
 category: Core
 created: 2023-01-04

--- a/cips/cip-6.md
+++ b/cips/cip-6.md
@@ -4,7 +4,8 @@ title: Mininum gas price enforcement
 description: Enforce payment of the gas for a transaction based on a governance modifiable global minimum gas price
 author: Callum Waters (@cmwaters)
 discussions-to: https://forum.celestia.org/t/cip-006-price-enforcement/1351
-status: Review
+status: Last Call
+last-call-deadline: 2024-05-22
 type: Standards Track
 category: Core
 created: 2023-11-30


### PR DESCRIPTION
Moves CIP-6 to last call and suggests a deadline two weeks from today.
Moves CIP-10 and CIP-14 to final because we passed the last call deadline.

