### PR TITLE
docs(cip-19): fix the reed solomon algorithm used for rows

### DIFF
--- a/cips/cip-19.md
+++ b/cips/cip-19.md
@@ -206,8 +206,9 @@ The fields with validity rules that form Row containers are:
 
 **SharesHalf**: A variable size [Share](#share) array representing either left or right half of a row. Which half side
 is defined by **HalfSide** field. Its length MUST be equal to the number of Column roots in [DAH][dah] divided by two.
-The opposite half is computed using Leopard GF16 Reed-Solomon erasure-coding. Afterward, the [NMT][nmt] is built over
-both halves and the computed NMT root MUST be equal to the respective Row root in [DAH][dah].
+The opposite half is computed using Leopard Reed-Solomon erasure-coding. The Leopard algorithm must operate over 8 bit
+Galois Fields for rows of total size less than or equal 256 shares or 16 bit GF otherwise. Afterward, the [NMT][nmt] is
+built over both halves and the computed NMT root MUST be equal to the respective Row root in [DAH][dah].
 
 **HalfSide**: An enum defining which side of the row **SharesHalf** field contains. It MUST be either **LEFT** or
 **RIGHT**.

--- a/cips/cip-19.md
+++ b/cips/cip-19.md
@@ -206,9 +206,9 @@ The fields with validity rules that form Row containers are:
 
 **SharesHalf**: A variable size [Share](#share) array representing either left or right half of a row. Which half side
 is defined by **HalfSide** field. Its length MUST be equal to the number of Column roots in [DAH][dah] divided by two.
-The opposite half is computed using Leopard Reed-Solomon erasure-coding. The Leopard algorithm must operate over 8 bit
-Galois Fields for rows of total size less than or equal 256 shares or 16 bit GF otherwise. Afterward, the [NMT][nmt] is
-built over both halves and the computed NMT root MUST be equal to the respective Row root in [DAH][dah].
+The opposite half is computed using Leopard Reed-Solomon erasure-coding. The Leopard algorithm must operate over 8-bit
+Galois Fields for rows of total size less than or equal to 256 shares or 16-bit GF otherwise. Afterward, the [NMT][nmt] is
+built over both halves, and the computed NMT root MUST be equal to the respective Row root in [DAH][dah].
 
 **HalfSide**: An enum defining which side of the row **SharesHalf** field contains. It MUST be either **LEFT** or
 **RIGHT**.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Correct specification of reed solomon algorithm used to encode/reconstruct the other half of shares present in a Row container.
Consensus uses leopard gf8 for squares with width not exceeding 256 shares.

Source: [default codec](https://github.com/celestiaorg/celestia-app/blob/main/pkg/appconsts/global_consts.go#L41) leading to [rsmt2d leopard construction](https://github.com/celestiaorg/rsmt2d/blob/main/leopard.go#L61) using [leopardAlways](https://github.com/klauspost/reedsolomon/blob/master/options.go#L293) which [selects between gf8 and gf16
](https://github.com/klauspost/reedsolomon/blob/master/reedsolomon.go#L420)
