### PR TITLE
docs(cip-24): move to last call

### DIFF
--- a/cips/cip-24.md
+++ b/cips/cip-24.md
@@ -4,7 +4,8 @@
 | description | Transition to hard fork-only updates for gas scheduler variables |
 | author | Nina Barbakadze ([@ninabarbakadze](https://github.com/ninabarbakadze)) |
 | discussions-to | <https://forum.celestia.org/t/cip-versioned-gas-scheduler-variables/1785> |
-| status | Review |
+| status | Last Call |
+| last-call-deadline | 2024-10-07 |
 | type | Standards Track |
 | category | Core |
 | created | 2024-07-24 |


### PR DESCRIPTION
We want to include this in v3 hence the shorter last call deadline of ~1 week. We'd like to get v3 on Arabica by Oct 7.