### PR TITLE
docs: remove index.html links in top level wg README links 

### DIFF
--- a/cips/wgs/README.md
+++ b/cips/wgs/README.md
@@ -3,8 +3,6 @@
 Here you will find all working groups
 and their meeting notes and recordings, if available.
 
-<!-- I don't really understand why `./da/README.md` etc. don't work, but they don't work locally for me  -->
-
-- [Data Availability](./da/index.html)
-- [Interface](./interface/index.html)
-- [ZK](./zk/index.html)
+- [Data Availability](./da)
+- [Interface](./interface)
+- [ZK](./zk)


### PR DESCRIPTION
While digging around the CIPs repo looking to catch up on what i'd missed the last few months, i noticed there was a front `README` link to the wgs which acted as a landing page, that then linked to each folder for each WG, but those were set as "index.html" and thus would 404 in GitHub. 

I've updated the top level /wg/README to link to each WG's folder where GitHub automatically will render the main README.md

eg: https://github.com/ramin/CIPs/blob/ramin/update-wg-links/cips/wgs/README.md
