### PR TITLE
CIP 18: Add tx priority to requests 

### DIFF
--- a/cips/cip-18.md
+++ b/cips/cip-18.md
@@ -38,8 +38,8 @@ The following API is proposed for the standardised gas estimation service.
 
 ```proto
 service GasEstimator {
-    rpc EstimateFee(EstimateFeeRequest) returns (EstimateFeeResponse) {}
-    rpc EstimateFeeAndGas(EstimateFeeAndGasRequest) returns (EstimateFeeAndGasResponse) {}
+    rpc EstimateGasPrice(EstimateGasPriceRequest) returns (EstimateGasPriceResponse) {}
+    rpc EstimateGasPriceAndUsage(EstimateGasPriceAndUsageRequest) returns (EstimateGasPriceAndUsageResponse) {}
 }
 
 enum TxPriority {
@@ -49,20 +49,20 @@ enum TxPriority {
   HIGH = 3;
 }
 
-message EstimateFeeRequest {
+message EstimateGasPriceRequest {
     TxPriority tx_priority = 1;
 }
 
-message EstimateFeeResponse {
+message EstimateGasPriceResponse {
     double estimated_gas_price = 1;
 }
 
-message EstimateFeeAndGasRequest {
+message EstimateGasPriceAndUsageRequest {
     TxPriority tx_priority = 1;
     cosmos.tx.Tx tx = 2;
 }
 
-message EstimateFeeAndGasResponse {
+message EstimateGasPriceAndUsageResponse {
     double estimated_gas_price = 1;
     uint64 estimated_gas_used = 2;
 }

--- a/cips/cip-18.md
+++ b/cips/cip-18.md
@@ -43,8 +43,7 @@ service GasEstimator {
 }
 
 enum TxPriority {
-  // Default value must always be 0 in proto3
-  UNKNOWN = 0;
+  NONE = 0;
   LOW = 1;
   MEDIUM = 2;
   HIGH = 3;

--- a/cips/cip-18.md
+++ b/cips/cip-18.md
@@ -59,7 +59,7 @@ message EstimateGasPriceResponse {
 
 message EstimateGasPriceAndUsageRequest {
     TxPriority tx_priority = 1;
-    cosmos.tx.Tx tx = 2;
+    bytes tx_bytes = 2;
 }
 
 message EstimateGasPriceAndUsageResponse {


### PR DESCRIPTION
This PR makes a few minor modifications to CIP 18:  Standardised Gas and Pricing Estimation Interface

- Remove the reference implementation section. Client and server implementations in the light and consensus node respectively will have their own ADRs that eventually can be linked in this CIP
- Add an optional `TxPriority` field to indicate the urgency for a transaction to be finalized in a block. It has three levels: low, medium, and high.
- Modify the APIs to have two methods: requesting just the gas price and requesting the gas price and the gas. The latter will be used for non-PFB transactions.
