### PR TITLE
docs(cip-12): withdraw

### DIFF
--- a/cips/cip-12.md
+++ b/cips/cip-12.md
@@ -4,7 +4,7 @@
 | description | Adding ics-29 to Celestia to move towards sustainable relayer funding for IBC |
 | author | Susannah Evans <susannah@interchain.io> ([@womensrights](https://github.com/womensrights)), Aditya Sripal <aditya@interchain.io> ([@AdityaSripal](https://github.com/AdityaSripal)) |
 | discussions-to | <https://forum.celestia.org/t/cip-relayer-incentivisation-middleware/1383> |
-| status | Review |
+| status | Withdrawn |
 | type | Standards Track |
 | category | Core |
 | created | 2023-12-12 |


### PR DESCRIPTION
Closes https://github.com/celestiaorg/CIPs/issues/120 because we don't need to add security considerations if we withdraw the proposal.

## Description
Withdraw CIP-12 because ICS-29 will be removed from ibc-go v10. See https://celestia-team.slack.com/archives/C047X1T6ERK/p1740423665065499

cc: @womensrights @AdityaSripal 