### PR TITLE
docs: withdraw cip-13

### DIFF
--- a/cips/cip-13.md
+++ b/cips/cip-13.md
@@ -4,10 +4,13 @@
 | description | Specification of Mainnet governance parameters in the Celestia network |
 | author | Yaz Khoury <yaz@celestia.org>, Evan Forbes <evan@celestia.org> |
 | discussions-to | <https://forum.celestia.org/t/cip-13-mainnet-on-chain-governance-parameters/1390> |
-| status | Draft |
+| status | Withdrawn |
 | type | Standards Track |
 | category | Core |
 | created | 2023-12-08 |
+
+> [!TIP]
+> This CIP has been withdrawn. See [celestia-app specs](https://celestiaorg.github.io/celestia-app/parameters.html) for versioned parameters and query on-chain for governance modifiable parameters.
 
 ## Abstract
 


### PR DESCRIPTION
CIP-13 is a maintenance burden and hasn't been updated to include new parameters added in v2 or v3. It also hasn't been updated to account for governance modifiable changes. This PR withdraws the CIP which seems safe because it never progressed past **Draft**.

Closes https://github.com/celestiaorg/CIPs/issues/204 
Closes https://github.com/celestiaorg/CIPs/issues/113
Closes https://github.com/celestiaorg/CIPs/pull/115