### PR TITLE
docs(cip-33): add prerequisite CIPs

### DIFF
--- a/cips/cip-033.md
+++ b/cips/cip-033.md
@@ -1,13 +1,13 @@
-| cip | 33 |
-| - | - |
-| title | Lotus Network Upgrade |
-| description | Reference specifications included in the Lotus Network Upgrade |
-| author | [@evan-forbes](https://github.com/evan-forbes) |
+| cip            | 33                                                                       |
+|----------------|--------------------------------------------------------------------------|
+| title          | Lotus Network Upgrade                                                    |
+| description    | Reference specifications included in the Lotus Network Upgrade           |
+| author         | [@evan-forbes](https://github.com/evan-forbes)                           |
 | discussions-to | <https://forum.celestia.org/t/lotus-application-v4-network-upgrade/1947> |
-| status | Draft |
-| type | Meta |
-| created | 2025-03-16 |
-| requires |  |
+| status         | Draft                                                                    |
+| type           | Meta                                                                     |
+| created        | 2025-03-16                                                               |
+| requires       | CIP-29, CIP-30, CIP-31, CIP-32                                           |
 
 ## Abstract
 


### PR DESCRIPTION
Oops I didn't notice that the `requires` field in the table was empty