### PR TITLE
chore: move v4 CIPs to last call

### DIFF
--- a/cips/cip-029.md
+++ b/cips/cip-029.md
@@ -1,10 +1,11 @@
 | cip            | 29                                                                                                                      |
 |----------------|-------------------------------------------------------------------------------------------------------------------------|
 | title          | Decrease inflation and disinflation                                                                                     |
-| description    | Decrease inflation and disinflation by 33%                                                                          |
+| description    | Decrease inflation and disinflation by 33%                                                                              |
 | author         | Dean Eigenmann ([@decanus](https://github.com/decanus)), Marko Baricevic ([@tac0turtle](https://github.com/tac0turtle)) |
 | discussions-to | <https://forum.celestia.org/t/cip-reduce-inflation/1896>                                                                |
-| status         | Review                                                                                                                  |
+| status         | Last Call                                                                                                               |
+| last-call-date | 2025-04-02                                                                                                              |
 | type           | Standards Track                                                                                                         |
 | category       | Core                                                                                                                    |
 | created        | 2025-02-04                                                                                                              |

--- a/cips/cip-030.md
+++ b/cips/cip-030.md
@@ -1,10 +1,11 @@
 | cip            | 30                                                                                                                      |
 |----------------|-------------------------------------------------------------------------------------------------------------------------|
-| title          | Disable the auto claim of staking rewards                                                                                   |
-| description    | Disable the auto claim of staking rewards when modifying delegations                                            |
+| title          | Disable the auto claim of staking rewards                                                                               |
+| description    | Disable the auto claim of staking rewards when modifying delegations                                                    |
 | author         | Dean Eigenmann ([@decanus](https://github.com/decanus)), Marko Baricevic ([@tac0turtle](https://github.com/tac0turtle)) |
 | discussions-to | <https://forum.celestia.org/t/cip-prevent-auto-claiming-of-staking-rewards/1905>                                        |
-| status         | Review                                                                                                                  |
+| status         | Last Call                                                                                                               |
+| last-call-date | 2025-04-02                                                                                                              |
 | type           | Standards Track                                                                                                         |
 | category       | Core                                                                                                                    |
 | created        | 2025-02-07                                                                                                              |

--- a/cips/cip-031.md
+++ b/cips/cip-031.md
@@ -5,7 +5,8 @@
 | description    | Dynamically update vesting schedules to include newly earned staking rewards                                            |
 | author         | Dean Eigenmann ([@decanus](https://github.com/decanus)), Marko Baricevic ([@tac0turtle](https://github.com/tac0turtle)) |
 | discussions-to | [Forum Discussion](https://forum.celestia.org/t/cip-lockup-accounts-staking-rewards/1908)                               |
-| status         | Review                                                                                                                   |
+| status         | Last Call                                                                                                               |
+| last-call-date | 2025-04-02                                                                                                              |
 | type           | Standards Track                                                                                                         |
 | category       | Core                                                                                                                    |
 | created        | 2025-02-07                                                                                                              |

--- a/cips/cip-032.md
+++ b/cips/cip-032.md
@@ -1,13 +1,14 @@
-| cip           | 32                                                                                         |
-|---------------|--------------------------------------------------------------------------------------------|
-| title         | Add Hyperlane to Celestia                                                                  |
-| description   | This CIP proposes adding Hyperlane to celestia-app.                                        |
-| author        | c-node [@c-node](https://github.com/S1nus), Callum Waters (@cmwaters)                      |
-| discussions-to| [forum](https://forum.celestia.org/t/cip-add-hyperlane-bridging/1909)                      |
-| status        | Review                                                                                     |
-| type          | Standards Track                                                                            |
-| category      | Core                                                                                       |
-| created       | 2025-02-21                                                                                 |
+| cip            | 32                                                                    |
+|----------------|-----------------------------------------------------------------------|
+| title          | Add Hyperlane to Celestia                                             |
+| description    | This CIP proposes adding Hyperlane to celestia-app.                   |
+| author         | c-node [@c-node](https://github.com/S1nus), Callum Waters (@cmwaters) |
+| discussions-to | [forum](https://forum.celestia.org/t/cip-add-hyperlane-bridging/1909) |
+| status         | Last Call                                                             |
+| last-call-date | 2025-04-02                                                            |
+| type           | Standards Track                                                       |
+| category       | Core                                                                  |
+| created        | 2025-02-21                                                            |
 
 ## Abstract
 

--- a/cips/cip-033.md
+++ b/cips/cip-033.md
@@ -4,7 +4,8 @@
 | description    | Reference specifications included in the Lotus Network Upgrade           |
 | author         | [@evan-forbes](https://github.com/evan-forbes)                           |
 | discussions-to | <https://forum.celestia.org/t/lotus-application-v4-network-upgrade/1947> |
-| status         | Review                                                                   |
+| status         | Last Call                                                                |
+| last-call-date | 2025-04-02                                                               |
 | type           | Meta                                                                     |
 | created        | 2025-03-16                                                               |
 | requires       | CIP-29, CIP-30, CIP-31, CIP-32                                           |


### PR DESCRIPTION
Addresses an action item from the most recent core devs call.