### PR TITLE
cip: Header Pruning for LNs

### DIFF
--- a/cips/README.md
+++ b/cips/README.md
@@ -74,6 +74,7 @@ Read [CIP-1](./cip-001.md) for information on the CIP process.
 | [32](./cip-032.md) | Add Hyperlane to Celestia                                                    | [@c-node](https://github.com/S1nus), [@cmwaters](https://github.com/cmwaters)                                                                                                |
 | [33](./cip-033.md) | Lotus Network Upgrade                                                        | [@evan-forbes](https://github.com/evan-forbes)                                                                                                                               |
 | [34](./cip-034.md) | Lower Sampling and Pruning Window to 14 days                                | [@cmwaters](https://github.com/cmwaters), [@Nashqueue](https://github.com/Nashqueue)                                                                                         |
+| [35](./cip-035.md) | Header Pruning for Light Nodes                                             | [@Wondertan](https://github.com/Wondertan)                                                                                                                                   |
 
 ## Contributing
 

--- a/cips/SUMMARY.md
+++ b/cips/SUMMARY.md
@@ -37,6 +37,7 @@
   - [CIP-32](./cip-032.md)
   - [CIP-33](./cip-033.md)
   - [CIP-34](./cip-034.md)
+  - [CIP-35](./cip-035.md)
 
 - [Core Devs Call notes](./notes/README.md)
   - [CDC #14](./notes/cdc-14.md)

--- a/cips/cip-035.md
+++ b/cips/cip-035.md
@@ -1,4 +1,4 @@
-| cip | XX (assigned by Editors) |
+| cip | 35 |
 | - | - |
 | title | Header Pruning for Light Nodes |
 | description | Mechanism to retain a fixed range of headers instead of whole history |


### PR DESCRIPTION
## Overview

CIP for Header Pruning. As Header Pruning breaks users, particularly by preventing historical queries(to be fixed in subsequent CIP), it was decided to promote this change to a CIP. 

This CIP start a series of DA targeted CIPs to optimize bandwidth and storage usage for LN, particularly targeting overhead brought by headers.