### PR TITLE
CIP 34: Improve the description and remove reference to header pruning

### DIFF
--- a/cips/cip-034.md
+++ b/cips/cip-034.md
@@ -12,7 +12,7 @@
 
 ## Abstract
 
-Lower the minimum sampling and pruning window to 14 days and 14 days + 1 hour respectively to reduce storage costs in response to increasing throughput of the network and to ensure that the subjective intialized header, known as **Tail**, in the header pruning CIP, is within the trusting period and thus not subject to long range attacks.
+Lower the minimum sampling and pruning window to 14 days and 14 days + 1 hour respectively to reduce storage costs in response to increasing throughput of the network and to ensure that the subjective intialized header which must be within the trusting period is able to sample all headers within the that sampling window without relying on backwards sync
 
 ## Parameters
 
@@ -26,7 +26,7 @@ Lower the minimum sampling and pruning window to 14 days and 14 days + 1 hour re
 
 The next pending increase in throughput (32 MB blocks every 6 seconds) would require bridge nodes to store up to 1 TB per day. The current sampling window (30 days) implies that pruned bridge nodes need to have 30 TB of storage. This CIP reduces the sampling window to 14 days to reduce the storage requirement to 14 TB which makes it less costly to serve data to the network.
 
-The current light node syncing logic involves performing sequential verification from genesis. Outside from the time and storage costs from syncing from genesis, it's also vulnerable to long range attacks as headers beyond the trusting period are based on validators with "nothing at stake". While the header pruning CIP, addresses these concerns, the safety issue is only addressed so long as the sampling window is equal to the trusting period (currently defaults as 14 days). Having a sampling window or header pruning window greater than the trusting period will compromise the security of a long range attack unless the node uses something like backwards sync.
+The current light node syncing logic involves performing sequential verification from genesis. Outside from the time and storage costs from syncing from genesis, it's also vulnerable to long range attacks as headers beyond the trusting period are based on validators with "nothing at stake". Having a sampling window or header pruning window greater than the trusting period will mean that nodes aren't capable, using sequential verification to sample all blocks within the window.
 
 ## Backwards Compatibility
 

--- a/cips/cip-034.md
+++ b/cips/cip-034.md
@@ -12,7 +12,7 @@
 
 ## Abstract
 
-Lower the minimum sampling and pruning window to 14 days and 14 days + 1 hour respectively to reduce storage costs in response to increasing throughput of the network and to ensure that the subjective intialized header which must be within the trusting period is able to sample all headers within the that sampling window without relying on backwards sync
+Lower the minimum sampling and pruning windows to 14 days and 14 days + 1 hour, respectively, to reduce storage costs in response to the network’s increasing throughput. This also ensures that the subjectively initialized header— which must be within the trusting period— can sample all headers within the sampling window without relying on backwards sync.
 
 ## Parameters
 

--- a/cips/cip-034.md
+++ b/cips/cip-034.md
@@ -26,7 +26,7 @@ Lower the minimum sampling and pruning windows to 14 days and 14 days + 1 hour, 
 
 The next pending increase in throughput (32 MB blocks every 6 seconds) would require bridge nodes to store up to 1 TB per day. The current sampling window (30 days) implies that pruned bridge nodes need to have 30 TB of storage. This CIP reduces the sampling window to 14 days to reduce the storage requirement to 14 TB which makes it less costly to serve data to the network.
 
-The current light node syncing logic involves performing sequential verification from genesis. Outside from the time and storage costs from syncing from genesis, it's also vulnerable to long range attacks as headers beyond the trusting period are based on validators with "nothing at stake". Having a sampling window or header pruning window greater than the trusting period will mean that nodes aren't capable, using sequential verification to sample all blocks within the window.
+The current light node syncing logic involves performing sequential verification from genesis. Outside from the time and storage costs from syncing from genesis, it's also vulnerable to long range attacks as headers beyond the trusting period are based on validators with "nothing at stake". Having a sampling window or header pruning window greater than the trusting period will mean that nodes aren't able to use sequential verification to sample all blocks within the window.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Based on the conversation at yesterdays core devs call, I have removed reference to the header pruning CIP and tried to make it independent focusin on the fact that the sampling window needs to be within trustingPeriod which is currently 14 days