### PR TITLE
chore: update 31 

### DIFF
--- a/cips/cip-031.md
+++ b/cips/cip-031.md
@@ -157,6 +157,8 @@ When upgrading to v4 we propose introducing a migration that will set the Parame
 
 The continuous and delayed vesting account types will be updated to implement CIP-31. Specifically, they will implement the `UpdateSchedule` function so that the original vesting amount can account for staking rewards. The periodic and permanent account types will not support CIP-31. They will be disallowed from being created.
 
+When delegating an account has the option to set another withdraw address, due to rewards needing to adhere to the original vesting schedule the withdraw address must be the same as the delegator address. This is to ensure that the rewards are locked up in the same account.
+
 ## Test Cases
 
 The implementation should include test cases covering:


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This update is around staking reward withdraw addresses. Due to the requirement that staking rewards must adhere to their vesting schedule it is required to keep the original delegation address as the withdraw address.  
