### PR TITLE
chore: move cip-31, cip-33 to final

### DIFF
--- a/cips/cip-031.md
+++ b/cips/cip-031.md
@@ -1,14 +1,13 @@
-| cip            | 31                                                                                                                      |
-|----------------|-------------------------------------------------------------------------------------------------------------------------|
-| title          | Incorporate staking rewards into vesting account schedules                                                              |
-| description    | Dynamically update vesting schedules to include newly earned staking rewards                                            |
-| author         | Dean Eigenmann ([@decanus](https://github.com/decanus)), Marko Baricevic ([@tac0turtle](https://github.com/tac0turtle)) |
-| discussions-to | [Forum Discussion](https://forum.celestia.org/t/cip-lockup-accounts-staking-rewards/1908)                               |
-| status         | Last Call                                                                                                               |
-| last-call-deadline | 2025-04-02                                                                                                              |
-| type           | Standards Track                                                                                                         |
-| category       | Core                                                                                                                    |
-| created        | 2025-02-07                                                                                                              |
+| cip                | 31                                                                                                                      |
+|--------------------|-------------------------------------------------------------------------------------------------------------------------|
+| title              | Incorporate staking rewards into vesting account schedules                                                              |
+| description        | Dynamically update vesting schedules to include newly earned staking rewards                                            |
+| author             | Dean Eigenmann ([@decanus](https://github.com/decanus)), Marko Baricevic ([@tac0turtle](https://github.com/tac0turtle)) |
+| discussions-to     | [Forum Discussion](https://forum.celestia.org/t/cip-lockup-accounts-staking-rewards/1908)                               |
+| status             | Final                                                                                                                   |
+| type               | Standards Track                                                                                                         |
+| category           | Core                                                                                                                    |
+| created            | 2025-02-07                                                                                                              |
 
 ---
 
@@ -159,7 +158,7 @@ The continuous and delayed vesting account types will be updated to implement CI
 
 Accounts are able to set a withdraw address that differs from their own address. Since rewards need to adhere to the original vesting schedule, the withdraw address for vesting accounts must be the same as the delegator address. This is to ensure that the rewards are locked up in the same account. Vesting accounts that have different withdraw addresses will have their withdraw address ignored. This means that the original vesting account will be used as the withdraw address.
 
-Alongside the above change, we will also be preventing the setting of different withdraw addresses for vesting accounts in the message server. 
+Alongside the above change, we will also be preventing the setting of different withdraw addresses for vesting accounts in the message server.
 
 ## Test Cases
 

--- a/cips/cip-033.md
+++ b/cips/cip-033.md
@@ -1,14 +1,13 @@
-| cip            | 33                                                                       |
-|----------------|--------------------------------------------------------------------------|
-| title          | Lotus Network Upgrade                                                    |
-| description    | Reference specifications included in the Lotus Network Upgrade           |
-| author         | [@evan-forbes](https://github.com/evan-forbes)                           |
-| discussions-to | <https://forum.celestia.org/t/lotus-application-v4-network-upgrade/1947> |
-| status         | Last Call                                                                |
-| last-call-deadline | 2025-04-02                                                               |
-| type           | Meta                                                                     |
-| created        | 2025-03-16                                                               |
-| requires       | [CIP-29](./cip-029.md), [CIP-30](./cip-030.md), [CIP-31](./cip-031.md), [CIP-32](./cip-032.md)                                           |
+| cip                | 33                                                                                             |
+|--------------------|------------------------------------------------------------------------------------------------|
+| title              | Lotus Network Upgrade                                                                          |
+| description        | Reference specifications included in the Lotus Network Upgrade                                 |
+| author             | [@evan-forbes](https://github.com/evan-forbes)                                                 |
+| discussions-to     | <https://forum.celestia.org/t/lotus-application-v4-network-upgrade/1947>                       |
+| status             | Final                                                                                          |
+| type               | Meta                                                                                           |
+| created            | 2025-03-16                                                                                     |
+| requires           | [CIP-29](./cip-029.md), [CIP-30](./cip-030.md), [CIP-31](./cip-031.md), [CIP-32](./cip-032.md) |
 
 ## Abstract
 


### PR DESCRIPTION
Move CIP-31 to final because we're done amending the CIP based on the implementation.

Move CIP-33 to final because now all the prerequisite CIPs are final