### PR TITLE
docs: add CIP-38 High-Throughput Block Recovery

### DIFF
--- a/cips/README.md
+++ b/cips/README.md
@@ -77,6 +77,7 @@ Read [CIP-1](./cip-001.md) for information on the CIP process.
 | [35](./cip-035.md) | Header Pruning for Light Nodes                                               | [@Wondertan](https://github.com/Wondertan)                                                                                                                                   |
 | [36](./cip-036.md) | Lowering Trusting Period to 7 Days                                           | [@nashqueue](https://github.com/nashqueue)                                                                                                                                   |
 | [37](./cip-037.md) | Lower unbonding period to ~14 days                                           | [@cmwaters](https://github.com/cmwaters)                                                                                                                                     |
+| [38](./cip-038.md) | High-Throughput Block Recovery                                                | [@evan-forbes](https://github.com/evan-forbes)                                                                                                                               |
 
 ## Contributing
 

--- a/cips/SUMMARY.md
+++ b/cips/SUMMARY.md
@@ -38,6 +38,9 @@
   - [CIP-33](./cip-033.md)
   - [CIP-34](./cip-034.md)
   - [CIP-35](./cip-035.md)
+  - [CIP-36](./cip-036.md)
+  - [CIP-37](./cip-037.md)
+  - [CIP-38](./cip-038.md)
 
 - [Core Devs Call notes](./notes/README.md)
   - [CDC #14](./notes/cdc-14.md)

--- a/cips/cip-038.md
+++ b/cips/cip-038.md
@@ -1,0 +1,39 @@
+| cip | 38 |
+| - | - |
+| title | High-Throughput Block Recovery |
+| description | Specifies a high-throughput block recovery mechanism using pull-based broadcast trees for efficient block data distribution |
+| author | Evan Forbes [@evan-forbes](https://github.com/evan-forbes) |
+| discussions-to | https://github.com/celestiaorg/celestia-app/pull/4285 |
+| status | Draft |
+| type | Standards Track |
+| category | Core |
+| created | 2025-06-23 |
+
+## Abstract
+
+This CIP specifies a high-throughput block recovery mechanism that uses pull-based broadcast trees to efficiently distribute block data across consensus nodes. The specification is maintained externally and this CIP serves as a formal reference to that specification.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+The complete specification for the high-throughput block recovery mechanism is being reviewed at:
+https://github.com/celestiaorg/celestia-app/blob/353f21116b2edb2b22df454df907567b50558b07/specs/src/recovery.md
+
+Implementations MUST follow the specification as defined in the referenced document.
+
+## Rationale
+
+Celestia currently relies on full replication of block data across all validators before voting. The protocol described in the spec does this.
+
+## Backwards Compatibility
+
+No backward compatibility issues found.
+
+## Security Considerations
+
+The referenced specification includes comprehensive security considerations for defending against sybil attacks and denial-of-service attacks, even when combining pull based logic with broadcast tree logic.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://github.com/celestiaorg/CIPs/blob/main/LICENSE).

--- a/cips/cip-038.md
+++ b/cips/cip-038.md
@@ -3,7 +3,7 @@
 | title | High-Throughput Block Recovery |
 | description | Specifies a high-throughput block recovery mechanism using pull-based broadcast trees for efficient block data distribution |
 | author | Evan Forbes [@evan-forbes](https://github.com/evan-forbes) |
-| discussions-to | https://github.com/celestiaorg/celestia-app/pull/4285 |
+| discussions-to | <https://github.com/celestiaorg/celestia-app/pull/4285> |
 | status | Draft |
 | type | Standards Track |
 | category | Core |
@@ -18,7 +18,7 @@ This CIP specifies a high-throughput block recovery mechanism that uses pull-bas
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
 The complete specification for the high-throughput block recovery mechanism is being reviewed at:
-https://github.com/celestiaorg/celestia-app/blob/353f21116b2edb2b22df454df907567b50558b07/specs/src/recovery.md
+<https://github.com/celestiaorg/celestia-app/blob/353f21116b2edb2b22df454df907567b50558b07/specs/src/recovery.md>
 
 Implementations MUST follow the specification as defined in the referenced document.
 


### PR DESCRIPTION
## Overview

adds cip-38, which is just a reference to the spec for using pull base broadcast trees. discussions can be found https://github.com/celestiaorg/celestia-app/pull/4285
