### PR TITLE
cip: Remove token filter for Hyperlane and IBC

### DIFF
--- a/cips/README.md
+++ b/cips/README.md
@@ -83,6 +83,7 @@ Read [CIP-1](./cip-001.md) for information on the CIP process.
 | [36](./cip-036.md) | Lowering Trusting Period to 7 Days                                           | [@nashqueue](https://github.com/nashqueue)                                                                                                                                   |
 | [37](./cip-037.md) | Lower unbonding period to ~14 days                                           | [@cmwaters](https://github.com/cmwaters)                                                                                                                                     |
 | [38](./cip-038.md) | High-Throughput Block Recovery                                                | [@evan-forbes](https://github.com/evan-forbes)                                                                                                                               |
+| [39](./cip-039.md) | Disable token filter for Hyperlane and IBC            | [@Manav-Aggarwal](https://github.com/Manav-Aggarwal)                                                                                                                         |
 
 ## Contributing
 

--- a/cips/README.md
+++ b/cips/README.md
@@ -83,7 +83,7 @@ Read [CIP-1](./cip-001.md) for information on the CIP process.
 | [36](./cip-036.md) | Lowering Trusting Period to 7 Days                                           | [@nashqueue](https://github.com/nashqueue)                                                                                                                                   |
 | [37](./cip-037.md) | Lower unbonding period to ~14 days                                           | [@cmwaters](https://github.com/cmwaters)                                                                                                                                     |
 | [38](./cip-038.md) | High-Throughput Block Recovery                                                | [@evan-forbes](https://github.com/evan-forbes)                                                                                                                               |
-| [39](./cip-039.md) | Disable token filter for Hyperlane and IBC            | [@Manav-Aggarwal](https://github.com/Manav-Aggarwal)                                                                                                                         |
+| [39](./cip-039.md) | Remove token filter for Hyperlane and IBC            | [@Manav-Aggarwal](https://github.com/Manav-Aggarwal)                                                                                                                         |
 
 ## Contributing
 

--- a/cips/SUMMARY.md
+++ b/cips/SUMMARY.md
@@ -41,6 +41,7 @@
   - [CIP-36](./cip-036.md)
   - [CIP-37](./cip-037.md)
   - [CIP-38](./cip-038.md)
+  - [CIP-39](./cip-039.md)
 
 - [Core Devs Call notes](./notes/README.md)
   - [CDC #14](./notes/cdc-14.md)

--- a/cips/cip-039.md
+++ b/cips/cip-039.md
@@ -3,7 +3,7 @@
 | title | Remove token filter for Hyperlane and IBC |
 | description | This CIP proposes removing the token filter in order to support non-TIA assets on the state machine. |
 | author | Manav Aggarwal ([@Manav-Aggarwal](https://github.com/Manav-Aggarwal)) |
-| discussions-to | TBD |
+| discussions-to | <https://forum.celestia.org/t/cip-remove-token-filter-for-hyperlane-and-ibc/2085> |
 | status | Draft |
 | type | Standards Track |
 | category | Core |

--- a/cips/cip-039.md
+++ b/cips/cip-039.md
@@ -70,46 +70,27 @@ No existing APIs, interfaces, or behaviors are modified - only new functionality
 
 ## Test Cases
 
-### Synthetic Token Creation Test
+- An E2E test that transfers a non-TIA asset via IBC from an IBC-enabled chain like Osmosis to Celestia Transfer. Verify the token appears in Celestia's state machine. Confirm token can be transferred via IBC to the same chain and also another IBC-enabled chain.
+- The same test as above with Hyperlane from/to a Hyperlane-enabled chain.
 
-- Transfer a non-TIA asset through Hyperlane to Celestia
-- Verify the token appears in Celestia's state
-- Confirm token can be transferred via IBC to another chain
+### Backward Compatibility
 
-### IBC Transfer Test
-
-- Transfer a non-TIA asset through IBC to Celestia
-- Verify the token appears in Celestia's state
-- Transfer the token to another chain via Hyperlane
-
-### Backward Compatibility Test
-
-- Ensure existing token functionality with TIA remains unchanged
 - Verify TIA transfers continue to work as expected
-- Confirm no regression in existing Hyperlane functionality
+- Confirm no regression in existing Hyperlane and IBC functionality
 
 ## Security Considerations
 
-### Synthetic Token Risks
-- **Token Validation**: Synthetic tokens must be properly validated through the Hyperlane integration to prevent malicious token creation
-- **Supply Management**: Synthetic tokens should have proper supply controls to prevent inflation attacks
-- **Cross-Chain Verification**: The underlying assets backing synthetic tokens must be properly verified on the origin chain
+Removing the token filter for Hyperlane and IBC introduces several security risks that must be carefully managed:
 
-### IBC Security
-- **Channel Security**: Removing the token filter increases the attack surface for IBC channels. Proper channel validation and monitoring are essential
-- **Asset Verification**: Without token filtering, additional validation mechanisms may be needed to ensure asset legitimacy
+### Primary Risk Categories
 
-### Mitigation Strategies
-- Leverage existing Hyperlane security mechanisms for token validation
-- Implement proper monitoring and alerting for synthetic token operations
-- Ensure thorough testing of cross-chain token transfers
-- Consider implementing rate limiting for synthetic token operations if needed
+**Malicious Token Introduction**: Arbitrary tokens can be bridged to Celestia, enabling spam tokens, malicious contracts, and potential rug pulls. Attackers could create worthless tokens to clog the network or deceive users with misleading metadata.
 
-### Audit Recommendations
-- Security audit of the WarpKeeper configuration changes
-- Review of IBC token filter removal implications
-- Testing of synthetic token creation and transfer flows
-- Validation of cross-chain security mechanisms
+**Network Resource Exhaustion**: Unlimited token types may lead to state bloat, transaction spam, and bridge congestion. Large volumes of worthless tokens could consume bridge liquidity and manipulate fee markets.
+
+### Risk Assessment
+
+These risks are consistent with other multi-chain ecosystems. The proposal's additive nature preserves existing TIA security while introducing risks primarily for users who choose to interact with bridged tokens.
 
 ## Copyright
 

--- a/cips/cip-039.md
+++ b/cips/cip-039.md
@@ -25,6 +25,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 To disable the token filter for Hyperlane, the WarpKeeper configuration MUST be modified to include synthetic token support by adding the `HYP_TOKEN_TYPE_SYNTHETIC` token type to the allowed token types array.
 
 **Current Configuration:**
+
 ```go
 app.WarpKeeper = warpkeeper.NewKeeper(
     encodingConfig.Codec,
@@ -38,6 +39,7 @@ app.WarpKeeper = warpkeeper.NewKeeper(
 ```
 
 **Updated Configuration:**
+
 ```go
 app.WarpKeeper = warpkeeper.NewKeeper(
     encodingConfig.Codec,
@@ -94,4 +96,4 @@ These risks are consistent with other multi-chain ecosystems. The proposal's add
 
 ## Copyright
 
-Copyright and related rights waived via [CC0](https://github.com/celestiaorg/CIPs/blob/main/LICENSE). 
+Copyright and related rights waived via [CC0](https://github.com/celestiaorg/CIPs/blob/main/LICENSE).

--- a/cips/cip-039.md
+++ b/cips/cip-039.md
@@ -1,0 +1,116 @@
+| cip | 39 |
+| - | - |
+| title | Remove token filter for Hyperlane and IBC |
+| description | This CIP proposes removing the token filter in order to support non-TIA assets on the state machine. |
+| author | Manav Aggarwal ([@Manav-Aggarwal](https://github.com/Manav-Aggarwal)) |
+| discussions-to | TBD |
+| status | Draft |
+| type | Standards Track |
+| category | Core |
+| created | 2025-07-04 |
+| requires | CIP-32 |
+
+## Abstract
+
+Currently, the state machine has a token filter which restricts the creation of non-native assets on it for both Hyperlane and IBC. This means that any asset other than TIA cannot be bridged to Celestia via its currently supported interoperability protocols: Hyperlane and IBC. This CIP proposes removing this token filter to allow any asset to be bridged to Celestia.
+
+## Motivation
+
+Currently, restricting token creation to only TIA on the state machine prevents Celestia from serving as an effective routing layer for cross-chain assets that have demand by Celestia-native applications. Removing this restriction lets Celestia-native applications to access any asset on any application also connected to Celestia by just making a connection to Celestia themselves. This lets Celestia serve as an effective routing layer for various assets to Celestia-native applications.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+To disable the token filter for Hyperlane, the WarpKeeper configuration MUST be modified to include synthetic token support by adding the `HYP_TOKEN_TYPE_SYNTHETIC` token type to the allowed token types array.
+
+**Current Configuration:**
+```go
+app.WarpKeeper = warpkeeper.NewKeeper(
+    encodingConfig.Codec,
+    encodingConfig.AddressCodec,
+    runtime.NewKVStoreService(keys[warptypes.ModuleName]),
+    govModuleAddr,
+    app.BankKeeper,
+    &app.HyperlaneKeeper,
+    []int32{int32(warptypes.HYP_TOKEN_TYPE_COLLATERAL)}, // Only collateral tokens
+)
+```
+
+**Updated Configuration:**
+```go
+app.WarpKeeper = warpkeeper.NewKeeper(
+    encodingConfig.Codec,
+    encodingConfig.AddressCodec,
+    runtime.NewKVStoreService(keys[warptypes.ModuleName]),
+    govModuleAddr,
+    app.BankKeeper,
+    &app.HyperlaneKeeper,
+    []int32{int32(warptypes.HYP_TOKEN_TYPE_COLLATERAL), int32(warptypes.HYP_TOKEN_TYPE_SYNTHETIC)}, // Add synthetic tokens
+)
+```
+
+To have similar functionality for IBC, the IBC token filter that prevents non-TIA tokens from being transferred via IBC MUST be removed to allow non-TIA assets to flow through IBC channels.
+
+This token filter implementation that currently exists in [`app/app.go` at line 357](https://github.com/celestiaorg/celestia-app/blob/c1f2a4c5c773f20c25043f98f4b8759b603ce825/app/app.go#L357).
+
+## Parameters
+
+This CIP does not introduce new parameters but modifies the existing Hyperlane and IBC implementations to disable the token filter.
+
+## Rationale
+
+The implementation requires only small modifications to the WarpKeeper configuration and removal of the IBC token filter, minimizing the risk of introducing bugs.
+
+## Backwards Compatibility
+
+This CIP is backward compatible. Existing functionality with moving around TIA will remain unchanged. The addition of non-TIA assets is purely additive and does not affect existing users or applications.
+
+No existing APIs, interfaces, or behaviors are modified - only new functionality is added.
+
+## Test Cases
+
+### Synthetic Token Creation Test
+
+- Transfer a non-TIA asset through Hyperlane to Celestia
+- Verify the token appears in Celestia's state
+- Confirm token can be transferred via IBC to another chain
+
+### IBC Transfer Test
+
+- Transfer a non-TIA asset through IBC to Celestia
+- Verify the token appears in Celestia's state
+- Transfer the token to another chain via Hyperlane
+
+### Backward Compatibility Test
+
+- Ensure existing token functionality with TIA remains unchanged
+- Verify TIA transfers continue to work as expected
+- Confirm no regression in existing Hyperlane functionality
+
+## Security Considerations
+
+### Synthetic Token Risks
+- **Token Validation**: Synthetic tokens must be properly validated through the Hyperlane integration to prevent malicious token creation
+- **Supply Management**: Synthetic tokens should have proper supply controls to prevent inflation attacks
+- **Cross-Chain Verification**: The underlying assets backing synthetic tokens must be properly verified on the origin chain
+
+### IBC Security
+- **Channel Security**: Removing the token filter increases the attack surface for IBC channels. Proper channel validation and monitoring are essential
+- **Asset Verification**: Without token filtering, additional validation mechanisms may be needed to ensure asset legitimacy
+
+### Mitigation Strategies
+- Leverage existing Hyperlane security mechanisms for token validation
+- Implement proper monitoring and alerting for synthetic token operations
+- Ensure thorough testing of cross-chain token transfers
+- Consider implementing rate limiting for synthetic token operations if needed
+
+### Audit Recommendations
+- Security audit of the WarpKeeper configuration changes
+- Review of IBC token filter removal implications
+- Testing of synthetic token creation and transfer flows
+- Validation of cross-chain security mechanisms
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://github.com/celestiaorg/CIPs/blob/main/LICENSE). 

--- a/cips/cip-039.md
+++ b/cips/cip-039.md
@@ -16,7 +16,7 @@ Currently, the state machine has a token filter which restricts the creation of 
 
 ## Motivation
 
-Currently, restricting token creation to only TIA on the state machine prevents Celestia from serving as an effective routing layer for cross-chain assets that have demand by Celestia-native applications. Removing this restriction lets Celestia-native applications to access any asset on any application also connected to Celestia by just making a connection to Celestia themselves. This lets Celestia serve as an effective routing layer for various assets to Celestia-native applications.
+Currently, restricting token creation to only TIA on the state machine prevents Celestia from serving as an effective routing layer for cross-chain assets that are in demand by Celestia-native applications. Removing this restriction allows Celestia-native applications to access any asset from any chain also connected to Celestia by simply making a connection to Celestia itself. This allows Celestia to serve as an effective routing layer, enabling various assets to reach Celestia-native applications.
 
 ## Specification
 
@@ -24,9 +24,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 To disable the token filter for Hyperlane, the WarpKeeper configuration MUST be modified to include synthetic token support by adding the `HYP_TOKEN_TYPE_SYNTHETIC` token type to the allowed token types array.
 
-**Current Configuration:**
-
-```go
+```diff
 app.WarpKeeper = warpkeeper.NewKeeper(
     encodingConfig.Codec,
     encodingConfig.AddressCodec,
@@ -34,46 +32,25 @@ app.WarpKeeper = warpkeeper.NewKeeper(
     govModuleAddr,
     app.BankKeeper,
     &app.HyperlaneKeeper,
-    []int32{int32(warptypes.HYP_TOKEN_TYPE_COLLATERAL)}, // Only collateral tokens
-)
-```
-
-**Updated Configuration:**
-
-```go
-app.WarpKeeper = warpkeeper.NewKeeper(
-    encodingConfig.Codec,
-    encodingConfig.AddressCodec,
-    runtime.NewKVStoreService(keys[warptypes.ModuleName]),
-    govModuleAddr,
-    app.BankKeeper,
-    &app.HyperlaneKeeper,
-    []int32{int32(warptypes.HYP_TOKEN_TYPE_COLLATERAL), int32(warptypes.HYP_TOKEN_TYPE_SYNTHETIC)}, // Add synthetic tokens
+-   []int32{int32(warptypes.HYP_TOKEN_TYPE_COLLATERAL)}, // Only collateral tokens
++   []int32{int32(warptypes.HYP_TOKEN_TYPE_COLLATERAL), int32(warptypes.HYP_TOKEN_TYPE_SYNTHETIC)}, // Add synthetic tokens
 )
 ```
 
 To have similar functionality for IBC, the IBC token filter that prevents non-TIA tokens from being transferred via IBC MUST be removed to allow non-TIA assets to flow through IBC channels.
 
-This token filter implementation that currently exists in [`app/app.go` at line 357](https://github.com/celestiaorg/celestia-app/blob/c1f2a4c5c773f20c25043f98f4b8759b603ce825/app/app.go#L357).
-
-## Parameters
-
-This CIP does not introduce new parameters but modifies the existing Hyperlane and IBC implementations to disable the token filter.
-
-## Rationale
-
-The implementation requires only small modifications to the WarpKeeper configuration and removal of the IBC token filter, minimizing the risk of introducing bugs.
+This token filter is currently implemented in [`app/app.go` at line 357](https://github.com/celestiaorg/celestia-app/blob/c1f2a4c5c773f20c25043f98f4b8759b603ce825/app/app.go#L357).
 
 ## Backwards Compatibility
 
-This CIP is backward compatible. Existing functionality with moving around TIA will remain unchanged. The addition of non-TIA assets is purely additive and does not affect existing users or applications.
+This CIP is backward compatible. Existing functionality for TIA transfers will remain unchanged. The addition of non-TIA assets is purely additive and does not affect existing users or applications.
 
-No existing APIs, interfaces, or behaviors are modified - only new functionality is added.
+However, note that this is a state machine breaking change and requires a major upgrade.
 
 ## Test Cases
 
-- An E2E test that transfers a non-TIA asset via IBC from an IBC-enabled chain like Osmosis to Celestia Transfer. Verify the token appears in Celestia's state machine. Confirm token can be transferred via IBC to the same chain and also another IBC-enabled chain.
-- The same test as above with Hyperlane from/to a Hyperlane-enabled chain.
+- An E2E test that transfers a non-TIA asset via IBC from an IBC-enabled chain like Osmosis to Celestia. Verify the token appears in Celestia's state machine. Confirm the token can be transferred via IBC to the same chain and also to another IBC-enabled chain.
+- The same test as above but with Hyperlane from/to a Hyperlane-enabled chain.
 
 ### Backward Compatibility
 
@@ -82,17 +59,15 @@ No existing APIs, interfaces, or behaviors are modified - only new functionality
 
 ## Security Considerations
 
-Removing the token filter for Hyperlane and IBC introduces several security risks that must be carefully managed:
+Removing the token filter for Hyperlane and IBC introduces security risks that must be carefully managed:
 
-### Primary Risk Categories
-
-**Malicious Token Introduction**: Arbitrary tokens can be bridged to Celestia, enabling spam tokens, malicious contracts, and potential rug pulls. Attackers could create worthless tokens to clog the network or deceive users with misleading metadata.
+### Primary Risk Category
 
 **Network Resource Exhaustion**: Unlimited token types may lead to state bloat, transaction spam, and bridge congestion. Large volumes of worthless tokens could consume bridge liquidity and manipulate fee markets.
 
 ### Risk Assessment
 
-These risks are consistent with other multi-chain ecosystems. The proposal's additive nature preserves existing TIA security while introducing risks primarily for users who choose to interact with bridged tokens.
+This risk is consistent with other multi-chain ecosystems. The proposal's additive nature preserves existing TIA security while introducing this risk primarily for users who choose to interact with bridged tokens.
 
 ## Copyright
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This cip proposes removing the token filter for Hyperlane and IBC. This makes Celestia a more effective routing layer for access to non-TIA assets for Celestia apps. 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
