### PR TITLE
Amend CIP-38 to also increase block size to 128MB and tx size to 8MB

### DIFF
--- a/cips/README.md
+++ b/cips/README.md
@@ -82,7 +82,7 @@ Read [CIP-1](./cip-001.md) for information on the CIP process.
 | [35](./cip-035.md) | Header Pruning for Light Nodes                                               | [@Wondertan](https://github.com/Wondertan)                                                                                                                                   |
 | [36](./cip-036.md) | Lowering Trusting Period to 7 Days                                           | [@nashqueue](https://github.com/nashqueue)                                                                                                                                   |
 | [37](./cip-037.md) | Lower unbonding period to ~14 days                                           | [@cmwaters](https://github.com/cmwaters)                                                                                                                                     |
-| [38](./cip-038.md) | High-Throughput Block Recovery                                                | [@evan-forbes](https://github.com/evan-forbes)                                                                                                                               |
+| [38](./cip-038.md) | Increase maximum block, square and transaction size                          | [@evan-forbes](https://github.com/evan-forbes)                                                                                                                               |
 | [39](./cip-039.md) | Remove token filter for Hyperlane and IBC            | [@Manav-Aggarwal](https://github.com/Manav-Aggarwal)                                                                                                                         |
 
 ## Contributing

--- a/cips/cip-038.md
+++ b/cips/cip-038.md
@@ -1,17 +1,17 @@
 | cip | 38 |
 | - | - |
-| title | High-Throughput Block Recovery |
-| description | Specifies a high-throughput block recovery mechanism using pull-based broadcast trees for efficient block data distribution |
-| author | Evan Forbes [@evan-forbes](https://github.com/evan-forbes) |
+| title | Increase maximum block, square and transaction size |
+| description | Increases the maximum block, square and transaction size to 128MB and 8MB respectively given the implemented high-throughput recovery mechanism |
+| author | Evan Forbes [@evan-forbes](https://github.com/evan-forbes), Callum Waters [@cmwaters](https://github.com/cmwaters) |
 | discussions-to | <https://github.com/celestiaorg/celestia-app/pull/4285> |
-| status | Draft |
+| status | Review |
 | type | Standards Track |
 | category | Core |
 | created | 2025-06-23 |
 
 ## Abstract
 
-This CIP specifies a high-throughput block recovery mechanism that uses pull-based broadcast trees to efficiently distribute block data across consensus nodes. The specification is maintained externally and this CIP serves as a formal reference to that specification.
+This CIP proposes a novel blob propagation mechanism that uses pull-based broadcast trees and erasure coded block parts to efficiently distribute block data across consensus nodes. In conjunction, these changes allow the network to safely increase the maximum block size to 128MB, the maximum original data square size to 512 and the maximum transaction size to 8MB.
 
 ## Specification
 
@@ -22,17 +22,30 @@ The complete specification for the high-throughput block recovery mechanism is b
 
 Implementations MUST follow the specification as defined in the referenced document.
 
+## Parameters
+
+The following parameter changes are proposed for the Celestia network:
+
+| Parameter | Current value | Proposed value | Description | Changeable via Governance |
+|-----------|---------------|----------------|-------------|---------------------------|
+| `MaxBlockSizeBytes` | 100 MiB | 128MB | Hardcoded value in CometBFT for the protobuf encoded block. | No |
+| `SquareSizeUpperBound` | 128 | 512 | Hardcoded maximum square size which limits the number of shares per row or column for the original data square | No |
+| `MaxTxSize` | 2 MiB | 8MiB | Maximum size of a transaction in bytes. | No |
+
 ## Rationale
 
 Celestia currently relies on full replication of block data across all validators before voting. The protocol described in the spec does this.
 
 ## Backwards Compatibility
 
-No backward compatibility issues found.
+This requires a major upgrade as these are network wide parameters. Nodes who upgrade will
+run both the old propagation and new propagation reactors. Upon the upgrade height, nodes will shutdown the old propogation reactor and communication will solely be across the new propagation reactor. If the need to fallback arises, nodes can coordinate amongst them to switch back to the old propagation reactor.
 
 ## Security Considerations
 
 The referenced specification includes comprehensive security considerations for defending against sybil attacks and denial-of-service attacks, even when combining pull based logic with broadcast tree logic.
+
+The implementation has been audited and the results can be found in the celestia-app repository. 
 
 ## Copyright
 

--- a/cips/cip-038.md
+++ b/cips/cip-038.md
@@ -45,7 +45,7 @@ run both the old propagation and new propagation reactors. Upon the upgrade heig
 
 The referenced specification includes comprehensive security considerations for defending against sybil attacks and denial-of-service attacks, even when combining pull based logic with broadcast tree logic.
 
-The implementation has been audited and the results can be found in the celestia-app repository. 
+The implementation has been audited and the results can be found in the celestia-app repository.
 
 ## Copyright
 

--- a/cips/cip-038.md
+++ b/cips/cip-038.md
@@ -1,7 +1,7 @@
 | cip | 38 |
 | - | - |
 | title | Increase maximum block, square and transaction size |
-| description | Increases the maximum block, square and transaction size to 128MB and 8MB respectively given the implemented high-throughput recovery mechanism |
+| description | Increases the maximum block size to 128MB, square size to 512, and transaction size to 8MB, enabled by a new high-throughput recovery mechanism |
 | author | Evan Forbes [@evan-forbes](https://github.com/evan-forbes), Callum Waters [@cmwaters](https://github.com/cmwaters) |
 | discussions-to | <https://github.com/celestiaorg/celestia-app/pull/4285> |
 | status | Review |
@@ -28,9 +28,9 @@ The following parameter changes are proposed for the Celestia network:
 
 | Parameter | Current value | Proposed value | Description | Changeable via Governance |
 |-----------|---------------|----------------|-------------|---------------------------|
-| `MaxBlockSizeBytes` | 100 MiB | 128MB | Hardcoded value in CometBFT for the protobuf encoded block. | No |
+| `MaxBlockSizeBytes` | 100 MiB | 128 MiB | Hardcoded value in CometBFT for the protobuf encoded block. | No |
 | `SquareSizeUpperBound` | 128 | 512 | Hardcoded maximum square size which limits the number of shares per row or column for the original data square | No |
-| `MaxTxSize` | 2 MiB | 8MiB | Maximum size of a transaction in bytes. | No |
+| `MaxTxSize` | 2 MiB | 8 MiB | Maximum size of a transaction in bytes. | No |
 
 ## Rationale
 


### PR DESCRIPTION
Since I believe the increasing in the throughput parameters should be in conjunction with the new block propagation protocol i.e. because of the proposed changes here we can increase block size to 128MB, I have decided to amend this CIP with the necessary parameter changes