### PR TITLE
Update CIP-29 inflation schedule to move reduction from Year 1.5 to Y…

### DIFF
--- a/cips/cip-029.md
+++ b/cips/cip-029.md
@@ -47,7 +47,8 @@ Below is the illustrative table showing the original versus the accelerated sche
 |--------:|-------------------:|-----------------------:|:-----------------------------------------------------------------------------------------------------------------|
 |   **0** |               8.00 |                   8.00 | Genesis year, no change.                                                                                         |
 |   **1** |               7.20 |                   7.20 |                                                                                                                  |
-| **1.5** |               7.20 |                5.00088 | Reduce year 0 inflation by 33% and additionally apply 6.7% disinfaltion, lowering the inflation rate to 5.00088% |
+| **1.5** |               7.20 |                   7.20 |                                                                                                                  |
+| **1.75** |               7.20 |                 4.914 | Reduce year 0 inflation by 33% and additionally apply 6.7% disinfaltion, lowering the inflation rate to 4.914% |
 |   **2** |               6.48 |                4.66582 | Regular annual disinflation applied (6.7%).                                                                      |
 |   **3** |               5.83 |                4.35321 | Regular annual disinflation applied (6.7%).                                                                      |
 |   **4** |               5.25 |                4.06155 | Regular annual disinflation applied (6.7%).                                                                      |
@@ -96,7 +97,8 @@ Updated schedule:
 |--------:|---------------:|-----------------:|-----------------:|-----------------:|
 |   **0** |            8.0 |            22.86 |             16.0 |            12.31 |
 |   **1** |            7.2 |            20.57 |             14.4 |            11.08 |
-| **1.5** |        5.00088 |          14.2882 |          10.0018 |          7.69366 |
+| **1.5** |            7.2 |            20.57 |             14.4 |            11.08 |
+| **1.75** |         4.914 |            14.04 |           9.828 |            7.56 |
 |   **2** |        4.66582 |          13.3309 |          9.33164 |          7.17819 |
 |   **3** |        4.35321 |          12.4377 |          8.70642 |          6.69725 |
 |   **4** |        4.06155 |          11.6044 |          8.12309 |          6.24853 |


### PR DESCRIPTION
…ear 1.75

- Year 1.5 now continues original schedule at 7.20% inflation
- Year 1.75 becomes the new point where 33% reduction takes effect (4.914%)
- Updated both inflation schedule and APR tables accordingly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
