### PR TITLE
docs(cip-19): add missing shwap IDs along with the containers

### DIFF
--- a/cips/cip-019.md
+++ b/cips/cip-019.md
@@ -364,8 +364,8 @@ RangeNamespaceDataID identifiers formatted as shown below:
 ```text
 RangeNamespaceDataID {
     EdsID;
-    From: u16;
-    To: u16;
+    From: u32;
+    To: u32;
 }
 ```
 


### PR DESCRIPTION
Added missing shwap types:
* IDs - NamespaceDataID, RangeNamespaceDataID
* Containers - NamespaceData, RangeNamespaceData
