### PR TITLE
docs(cip-43): add fee address module specification

### DIFF
--- a/cips/cip-043.md
+++ b/cips/cip-043.md
@@ -120,7 +120,7 @@ The fee forward transaction skips standard ante decorators for fee deduction, mi
 
 ### Distribution
 
-Forwarded fees are sent to the fee collector module. The distribution module allocates fee collector funds to validators and their delegators proportionally at `BeginBlock`. This distribution mechanism may be modified in future protocol upgrades.
+Forwarded fees are sent to the fee collector module account. The distribution module allocates fee collector funds to validators and their delegators proportionally at `BeginBlock`. This distribution mechanism may be modified in future protocol upgrades.
 
 ### Event
 


### PR DESCRIPTION
## Summary

Closes #301 

Adds CIP-43 specification for the fee address module (`x/feeaddress`), which enables networks to contribute TIA to protocol revenue via a simple bank send.

**Why this design**: Networks using Celestia typically don't maintain funded accounts—they only have bridge access (IBC, Hyperlane). Bridges can deliver tokens but can't set tx fees. Additionally, dashboards (Blockworks, Celenium) calculate revenue by aggregating `tx.AuthInfo.Fee` fields, so a direct bank transfer wouldn't appear as revenue. The protocol-injected transaction approach solves both problems.

## Fee Address

```
celestia1feefeefeefeefeefeefeefeefeefeefe8pxlcf
```

A vanity address ("fee" repeated) where sent TIA is automatically forwarded to protocol revenue.

## Key Features

- **Simple UX**: Standard `bank send` to contribute to protocol revenue
- **Multi-path Support**: Works via bank send, IBC transfer, and Hyperlane
- **Dashboard Compatible**: Protocol-injected transactions appear as real tx fees in analytics dashboards
- **Stateless**: No cumulative tracking, minimal complexity
- **Denom Restricted**: Only utia allowed (enforced by ante decorator + IBC middleware)

## How It Works

1. User sends utia to fee address
2. PrepareProposal injects `MsgForwardFees` tx with fee = balance
3. ProcessProposal strictly enforces fee forwarding
4. Forwarded amount appears as real transaction fee (protocol revenue)

**Note:** Protocol revenue is currently distributed to validators via the distribution module. This distribution mechanism may be modified in future protocol upgrades.

## Reference Implementation

https://github.com/celestiaorg/celestia-app/pull/6407