### PR TITLE
docs(cip-43): protocol-injected tx for dashboard-compatible fee forwarding

### DIFF
--- a/cips/cip-043.md
+++ b/cips/cip-043.md
@@ -1,7 +1,7 @@
 | cip | 43 |
 | - | - |
 | title | Fee address module |
-| description | Contribute TIA tokens to protocol fee revenue via a vanity fee address |
+| description | Forward TIA tokens to protocol revenue via a dedicated fee address |
 | author | Manav Aggarwal ([@Manav-Aggarwal](https://github.com/Manav-Aggarwal)) |
 | discussions-to | <https://forum.celestia.org/t/cip-add-burn-module/2216> |
 | status | Draft |
@@ -11,11 +11,17 @@
 
 ## Abstract
 
-This proposal introduces a fee address module (`x/feeaddress`) that allows users to contribute TIA tokens to protocol fee revenue by sending them to a vanity fee address. Tokens sent to this address are automatically forwarded to the fee collector at the end of each block.
+This proposal introduces a fee address module (`x/feeaddress`) that allows users to send TIA tokens to a dedicated address, which are then automatically forwarded to protocol revenue as transaction fees via protocol-injected transactions.
 
 ## Motivation
 
-The fee address mechanism enables applications to easily contribute to protocol fee revenue. For example, rollups could forward a portion of blob fees, or applications could share revenue with the protocol. Using a fee address rather than a specialized message simplifies the user experience—users can contribute with a standard `bank send` transaction.
+The fee address mechanism enables applications to contribute to protocol revenue in a way that is compatible with blockchain analytics dashboards. For example:
+
+- Rollups could send a portion of blob fees to protocol revenue
+- Applications could share revenue with the protocol
+- Cross-chain bridges (e.g., Hyperlane) could forward fees to protocol revenue
+
+By converting fee address funds into real transaction fees (rather than direct transfers), the forwarded amounts appear in dashboard revenue calculations that aggregate transaction fees.
 
 ## Specification
 
@@ -23,84 +29,120 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### New Module: `x/feeaddress`
 
-The fee address module manages a special fee address and forwards received tokens to the fee collector.
+The fee address module is intentionally stateless and relies entirely on existing Cosmos SDK modules for token operations.
 
 ### Fee Address
 
-```text
+Tokens MUST be sent to the following vanity address:
+
+```
 celestia1feefeefeefeefeefeefeefeefeefeefe8pxlcf
 ```
 
-This is a vanity address that encodes to "fee" repeated multiple times, making it recognizable as a fee destination. The address has no known private key, ensuring tokens sent there can only be handled by the module.
+This address is derived from a recognizable byte pattern that encodes to "feefee..." in bech32, making it easily identifiable as a fee destination.
 
-### State
+### Message Types
 
-The fee address module is stateless. It does not track cumulative forwarded tokens.
+#### MsgForwardFees
 
-### Supported Transfer Methods
+This message is protocol-injected and MUST NOT be submitted by users directly.
 
-- **Bank Send**: `MsgSend` and `MsgMultiSend` with fee address as recipient
-- **IBC Transfer**: `MsgTransfer` with fee address as receiver (inbound transfers validated by middleware)
-- **Hyperlane**: Inbound transfers landing at fee address are forwarded
-
-### Validation: FeeAddressDecorator
-
-The `FeeAddressDecorator` ante handler validates transactions containing:
-
-- `MsgSend` - checks `ToAddress`
-- `MsgMultiSend` - checks all `Outputs[].Address`
-- `MsgTransfer` (IBC) - checks `Receiver`
-- `MsgExec` (authz) - recursively validates all nested messages
-
-If recipient is the fee address, only `utia` denomination is allowed. Transactions attempting to send non-utia tokens to the fee address are rejected.
-
-### Validation: FeeAddressIBCMiddleware
-
-The `FeeAddressIBCMiddleware` intercepts inbound IBC transfers (`OnRecvPacket`). If the receiver is the fee address:
-
-- **Allowed**: Native `utia` (including utia returning from other chains with IBC prefixes like `transfer/channel-0/utia`)
-- **Rejected**: Foreign tokens (e.g., `uosmo`, `uatom`, or any non-utia denom)
-
-Rejected transfers receive an error acknowledgement, causing the sender to be refunded on the source chain.
-
-### EndBlocker
-
-At the end of each block:
-
-1. Check fee address `utia` balance
-2. If zero, return early (no-op)
-3. Transfer tokens from fee address to fee collector module account
-4. Emit `EventFeeForwarded` with sender address and amount
-
-**Note:** Protocol fee revenue is currently distributed to validators as staking rewards via the distribution module. This distribution mechanism may change in the future via protocol upgrades.
-
-### Queries
-
-#### FeeAddress
-
-Returns the fee address for programmatic discovery.
-
-```shell
-grpcurl -plaintext localhost:9090 celestia.feeaddress.v1.Query/FeeAddress
+```protobuf
+message MsgForwardFees {
+  // Hex-encoded block proposer address for validation
+  string proposer = 1;
+}
 ```
+
+The message has no signer - it is validated by checking the proposer matches the block proposer.
+
+### Validation Rules
+
+The following ante decorators and IBC middleware enforce token restrictions:
+
+- Only `utia` (the native staking token) MAY be sent to the fee address
+- Attempts to send other denoms (IBC tokens, etc.) MUST be rejected
+- IBC transfers to the fee address MUST be rejected to prevent foreign tokens from getting stuck
+
+### Protocol-Injected Fee Forward Transaction
+
+#### PrepareProposal
+
+When preparing a block proposal, the block proposer:
+
+1. Queries the fee address `utia` balance
+2. If balance is non-zero:
+   - Creates a `MsgForwardFees` transaction
+   - Sets the transaction fee to the **entire fee address balance**
+   - Sets gas limit to 50,000 (minimal, no computation)
+   - Does NOT sign the transaction (unsigned)
+   - Prepends the transaction to the block
+
+#### ProcessProposal (Strict Validation)
+
+All validators MUST enforce strict validation:
+
+1. If fee address has a non-zero balance:
+   - Block MUST contain a valid `MsgForwardFees` tx as the **first transaction**
+   - Tx fee MUST equal the fee address balance
+   - Proposer in message MUST match block proposer
+   - Block is REJECTED if any of these conditions fail
+2. If fee address has zero balance:
+   - Block MUST NOT contain a `MsgForwardFees` tx
+   - Block is REJECTED if a fee forward tx is present
+
+#### Ante Handler: FeeForwardDecorator
+
+The `FeeForwardDecorator` processes `MsgForwardFees` transactions:
+
+1. Validates that the proposer matches the block proposer
+2. Deducts the transaction fee from the fee address (not from a signer)
+3. Sends the fee to the fee collector module
+4. Sets context flags to skip signature verification (the tx is unsigned)
+
+Decorators that are skipped for fee forward transactions:
+- `DeductFeeDecorator` (fee already deducted by FeeForwardDecorator)
+- `SetPubKeyDecorator` (no signers)
+- `ValidateSigCountDecorator` (no signatures)
+- `SigGasConsumeDecorator` (no signatures)
+- `SigVerificationDecorator` (no signatures)
+- `IncrementSequenceDecorator` (no signers)
+
+### Distribution
+
+Forwarded fees are sent to the fee collector module, which contributes to protocol revenue. Currently, the distribution module allocates fee collector funds to validators at `BeginBlock` as staking rewards. This distribution mechanism may be modified in future protocol upgrades (e.g., to allocate a portion elsewhere).
 
 ### Event
 
 ```protobuf
 message EventFeeForwarded {
-  string sender = 1;  // Fee address
+  string from = 1;    // Address tokens were forwarded from
   string amount = 2;  // Amount forwarded (e.g., "1000000utia")
+}
+```
+
+### Query
+
+```protobuf
+service Query {
+  rpc FeeAddress(QueryFeeAddressRequest) returns (QueryFeeAddressResponse);
+}
+
+message QueryFeeAddressRequest {}
+
+message QueryFeeAddressResponse {
+  string fee_address = 1;
 }
 ```
 
 ### CLI Usage
 
 ```shell
-# Bank send
-celestia-appd tx bank send <from-key> celestia1feefeefeefeefeefeefeefeefeefeefe8pxlcf 1000000utia
+# Send tokens to the fee address (forwarded to protocol revenue in next block)
+celestia-appd tx bank send mykey celestia1feefeefeefeefeefeefeefeefeefeefe8pxlcf 1000000utia
 
-# IBC transfer
-celestia-appd tx ibc-transfer transfer <channel> celestia1feefeefeefeefeefeefeefeefeefeefe8pxlcf 1000000utia --from <key>
+# Query the fee address
+celestia-appd query feeaddress fee-address
 ```
 
 ## Parameters
@@ -109,41 +151,59 @@ This module introduces no new parameters.
 
 ## Rationale
 
-The fee address approach offers several advantages over a dedicated message:
+### Dashboard Compatibility
 
-1. **Simplicity**: Users contribute with standard `bank send` rather than learning a new message type
-2. **Interoperability**: Supports forwarding via IBC transfers and Hyperlane without additional message types
-3. **Tooling Compatibility**: Works with existing wallets and tools that support bank sends
-4. **Discoverability**: The vanity address ("fee" repeated) clearly conveys "tokens go to fees"
-5. **Fee Revenue**: Forwarded tokens contribute to protocol fee revenue
+Blockchain analytics dashboards (e.g., Blockworks, Celenium) calculate protocol revenue by aggregating transaction fees from the `tx.AuthInfo.Fee` field. A naive design using direct bank transfers in EndBlocker would not appear in these revenue calculations.
 
-The module is intentionally stateless—it does not track cumulative forwarded tokens. This simplifies the implementation and avoids state bloat.
+By injecting a real transaction with the fee address balance as its fee, the forwarded amount appears as actual transaction fee revenue.
+
+### Protocol-Injected vs. External Relayer
+
+An external relayer could theoretically submit fee forward transactions, but this introduces:
+- Liveness dependencies on external infrastructure
+- Trust assumptions about relayer behavior
+- Potential MEV extraction
+
+Protocol injection ensures the fee forward transaction is created deterministically by the block proposer.
+
+### Strict Enforcement
+
+ProcessProposal strictly enforces fee forwarding to ensure:
+- No block proposer can "skip" forwarding to keep funds in the fee address
+- Consensus on when/how funds are forwarded
+- Predictable behavior for applications sending to the fee address
+
+### Other Design Decisions
+
+1. **No minimum balance threshold**: Forward any non-zero balance to minimize complexity
+2. **One transaction per block**: Fee address balance converts to single tx fee
+3. **Unsigned transaction**: Validated via proposer address match, not signature
+4. **Gas limit**: 50,000 (minimal - message handler only emits an event)
 
 ## Backwards Compatibility
 
-This is a consensus-breaking change that requires a network upgrade. However, it is purely additive (new module, new ante decorator, new IBC middleware) and does not affect existing functionality.
+This is a consensus-breaking change that requires a network upgrade. However, it is purely additive (new module) and does not affect existing functionality.
 
 ## Test Cases
 
 Test cases are available in the reference implementation:
 
-- Unit tests: `x/feeaddress/keeper_test.go` (EndBlocker, event emission, error handling)
-- Ante decorator tests: `x/feeaddress/ante/fee_address_decorator_test.go` (MsgSend, MsgMultiSend, MsgTransfer, MsgExec validation)
-- IBC middleware tests: `app/ibc_fee_middleware_test.go` (utia allowed, non-utia rejected, multi-hop scenarios)
-- Integration tests: `x/feeaddress/test/feeaddress_test.go` (full send-and-forward flow, query tests)
+- Unit tests: `x/feeaddress/keeper_test.go`
+- Integration tests: `x/feeaddress/test/feeaddress_test.go`
+
+Tests cover successful forwarding, wrong denom rejection, IBC rejection, event emission, and ProcessProposal validation.
 
 ## Security Considerations
 
-1. **Denom Restriction**: Only `utia` can be sent to the fee address. This is enforced by `FeeAddressDecorator` (for local transactions) and `FeeAddressIBCMiddleware` (for IBC transfers). This prevents forwarding of IBC tokens, Hyperlane tokens, or any other bridged assets. Forwarding bridged assets would cause accounting discrepancies between chains.
+1. **Denom Restriction**: Only `utia` can be sent to the fee address. This is enforced by ante decorators and IBC middleware. This prevents IBC tokens or other bridged assets from getting stuck at the fee address with no way to recover them.
 
-2. **Spam Mitigation**: No rate limiting is implemented as gas costs naturally discourage spam.
+2. **IBC Protection**: IBC transfers to the fee address are rejected at the middleware level to prevent foreign tokens from being transferred via IBC.
 
-3. **ICA Bypass (Accepted Risk)**: ICA host messages bypass the ante handler chain. If an ICA controller on another chain executes `MsgSend` with the fee address as recipient, the fee address restriction is not enforced. Non-utia tokens sent this way would be permanently stuck (not forwarded, not stolen). This is documented and accepted because:
-   - Stuck tokens do not benefit any party (they are not stolen, just inaccessible)
-   - ICA usage is uncommon and requires explicit controller setup on another chain
-   - The operational complexity of mitigating this edge case outweighs the risk
+3. **No Direct Access**: Users cannot withdraw from the fee address. Tokens are automatically forwarded as transaction fees.
 
-4. **Hyperlane Inbound**: Hyperlane `MsgProcessMessage` bypasses ante handlers. Non-utia tokens bridged to the fee address via Hyperlane would be permanently stuck. Users should avoid sending non-utia to the fee address via Hyperlane.
+4. **Proposer Validation**: The `MsgForwardFees` proposer field MUST match the block proposer, preventing unauthorized fee forwarding.
+
+5. **Strict Enforcement**: Blocks that fail to forward non-zero balances are rejected, preventing proposers from withholding funds.
 
 ## Reference Implementation
 


### PR DESCRIPTION
## Summary
Update CIP-43 to describe the protocol-injected transaction design for dashboard-compatible fee forwarding.

## Changes
- Add `MsgForwardFees` message type specification
- Document PrepareProposal injection mechanism
- Document ProcessProposal strict validation
- Add dashboard compatibility rationale
- Update security considerations for unsigned transactions

## Reference Implementation
celestiaorg/celestia-app#6412

🤖 Generated with [Claude Code](https://claude.ai/code)