### PR TITLE
fix: update CIP-043 created date to 2026

### DIFF
--- a/cips/cip-043.md
+++ b/cips/cip-043.md
@@ -7,7 +7,7 @@
 | status | Draft |
 | type | Standards Track |
 | category | Core |
-| created | 2025-01-14 |
+| created | 2026-01-14 |
 
 ## Abstract
 


### PR DESCRIPTION
## Summary
- Fixes the created date in CIP-043 from 2025 to 2026

## Test plan
- [x] Verified single-line change via `git diff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)