### PR TITLE
docs(cip-45): sync with implementation PR #6427

### DIFF
--- a/cips/cip-045.md
+++ b/cips/cip-045.md
@@ -67,7 +67,7 @@ message ForwardingResult {
 
 ```protobuf
 message QueryDeriveForwardingAddressRequest {
-  uint32 dest_domain = 1;    // Destination chain domain ID
+  uint32 dest_domain = 1;    // Hyperlane destination domain ID
   string dest_recipient = 2; // 32-byte recipient (hex-encoded)
 }
 


### PR DESCRIPTION
## Summary

Syncs CIP-45 specification with the implementation in celestia-app PR #6427. The implementation made several changes during code review that need to be reflected in the CIP.

## Changes

- **Remove params infrastructure**: Module is now stateless - removed `MsgUpdateParams`, `Params`, and Parameters section
- **Add DeriveForwardingAddress query**: Added missing query definition to Query Types section
- **Rename TokenForwardResult → ForwardingResult**: Match implementation naming
- **Add EventTokensStuck event**: New event for tokens stuck in module account after recovery failure
- **Update Reference Implementation**: Point to consolidated PR #6427 instead of individual PRs

## Related

- Implementation: https://github.com/celestiaorg/celestia-app/pull/6427

🤖 Generated with [Claude Code](https://claude.com/claude-code)