### PR TITLE
docs(cip-44): auto migrate max commission to 60%

### DIFF
--- a/cips/cip-044.md
+++ b/cips/cip-044.md
@@ -25,11 +25,11 @@ Increasing these bounds provides validators with greater flexibility to price th
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
 1. **Increase Minimum Commission Rate**: Raise the minimum validator commission from 10% to 20%.
-1. **Increase Maximum Commission Rate**: Raise the maximum validator commission from 25% to 60%.
-1. **Automatic Migration**:
+2. **Increase Maximum Commission Rate**: Raise the maximum validator commission from 25% to 60%.
+3. **Automatic Migration**:
     - Validators with commission below 20% MUST be automatically adjusted to 20% during the upgrade.
     - Validators with max commission rates below 60% MUST be automatically adjusted to 60% during the upgrade.
-1. **Commission Change Rules**: Existing commission change rate limits remain in effect.
+4. **Commission Change Rules**: Existing commission change rate limits remain in effect.
 
 ## Parameters
 


### PR DESCRIPTION
Context https://github.com/celestiaorg/celestia-app/issues/6437

The important change in this PR is

```diff
+ - Validators with max commission rates below 60% MUST be automatically adjusted to 60% during the upgrade.
```