### PR TITLE
docs(cip-43): sync with final implementation PR #6441

### DIFF
--- a/cips/cip-043.md
+++ b/cips/cip-043.md
@@ -11,7 +11,7 @@
 
 ## Abstract
 
-This proposal introduces a fee address module (`x/feeaddress`) that allows users to send TIA tokens to a dedicated address, which are then automatically forwarded to the fee collector module account as transaction fees via protocol-injected transactions. These fees are distributed to validators and delegators through the existing distribution module.
+This proposal introduces a fee address that allows users to send TIA tokens to a dedicated module account, which are then automatically forwarded to the fee collector as transaction fees via protocol-injected transactions. These fees are distributed to delegators through the existing distribution module.
 
 ## Motivation
 
@@ -44,31 +44,37 @@ This CIP intentionally does **not** address:
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-### New Module: `x/feeaddress`
+### Architecture
 
-The fee address module is intentionally stateless and relies entirely on existing Cosmos SDK modules for token operations.
+The fee address functionality is intentionally minimal with no dedicated module:
+
+- **Types**: `pkg/feeaddress/` contains `MsgPayProtocolFee` and validation logic
+- **Ante handlers**: `app/ante/` contains `FeeAddressDecorator` (denom validation) and `ProtocolFeeTerminatorDecorator` (protocol fee handling)
+- **Module account**: Registered in `maccPerms` for token operations
 
 ### Fee Address
 
-Tokens MUST be sent to the following vanity address:
+Tokens MUST be sent to the following module account:
 
 ```text
-celestia1feefeefeefeefeefeefeefeefeefeefe8pxlcf
+celestia18sjk23yldd9dg7j33sk24elwz2f06zt7ahx39y
 ```
 
-This address is derived from a recognizable byte pattern that encodes to "feefee..." in bech32, making it easily identifiable as a fee destination.
+This address is derived from the module name "feeaddress" using standard Cosmos SDK module account derivation.
 
 ### Message Types
 
-#### MsgForwardFees
+#### MsgPayProtocolFee
 
 This message is protocol-injected and MUST NOT be submitted by users directly.
 
 ```protobuf
-message MsgForwardFees {}
+message MsgPayProtocolFee {
+  string from_address = 1;
+}
 ```
 
-The message has no signer and no fields. Validation happens entirely via ProcessProposal checking that `tx fee == fee address balance`.
+The `from_address` field is always set to the fee address. The message includes a signer annotation for SDK compatibility, but signature verification is skipped by the `ProtocolFeeTerminatorDecorator`. Validation happens via ProcessProposal checking that `tx fee == fee address balance`.
 
 ### Validation Rules
 
@@ -87,73 +93,54 @@ When preparing a block proposal, the block proposer:
 
 1. Queries the fee address `utia` balance
 2. If balance is non-zero:
-   - Creates a `MsgForwardFees` transaction
+   - Creates a `MsgPayProtocolFee` transaction with `from_address` set to the fee address
    - Sets the transaction fee to the **entire fee address balance**
-   - Sets gas limit to 50,000 (minimal, no computation)
+   - Sets gas limit to 40,000 (minimal, no computation)
    - Does NOT sign the transaction (unsigned)
    - Prepends the transaction to the block
 
-Note: The fee forward tx is minimal (~100 bytes). If a block cannot accommodate it (practically impossible), tokens remain in the fee address until the next block.
+Note: The protocol fee tx is minimal (~100 bytes). If a block cannot accommodate it (practically impossible), tokens remain in the fee address until the next block.
 
 #### ProcessProposal (Strict Validation)
 
-PrepareProposal is proposer-controlled, so ProcessProposal MUST independently verify fee forwarding to prevent malicious proposers from withholding funds.
+PrepareProposal is proposer-controlled, so ProcessProposal MUST independently verify protocol fee forwarding to prevent malicious proposers from withholding funds.
 
 All validators MUST enforce strict validation:
 
 1. If fee address has a non-zero balance:
-   - Block MUST contain a valid `MsgForwardFees` tx as the **first transaction**
+   - Block MUST contain a valid `MsgPayProtocolFee` tx as the **first transaction**
    - Tx fee MUST equal the fee address balance
    - Block is REJECTED if any of these conditions fail
 2. If fee address has zero balance:
-   - Block MUST NOT contain a `MsgForwardFees` tx
-   - Block is REJECTED if a fee forward tx is present
+   - Block MUST NOT contain a `MsgPayProtocolFee` tx
+   - Block is REJECTED if a protocol fee tx is present
 
-#### Ante Handler: FeeForwardDecorator
+#### Ante Handler: ProtocolFeeTerminatorDecorator
 
-The `FeeForwardDecorator` processes `MsgForwardFees` transactions:
+The `ProtocolFeeTerminatorDecorator` processes `MsgPayProtocolFee` transactions:
 
-1. Deducts the transaction fee from the fee address (not from a signer)
-2. Sends the fee to the fee collector module
-3. Bypasses signature and sequence checks (the tx is unsigned and protocol-injected)
+1. Rejects user-submitted `MsgPayProtocolFee` transactions (only protocol-injected allowed)
+2. Deducts the transaction fee from the fee address (not from a signer)
+3. Sends the fee to the fee collector module
+4. Terminates the ante chain early, bypassing signature and sequence checks
 
-The fee forward transaction skips standard ante decorators for fee deduction, min gas price validation, signature verification, and sequence increment. See the reference implementation for the complete bypass list.
+The protocol fee transaction skips standard ante decorators for fee deduction, min gas price validation, signature verification, and sequence increment. See the reference implementation for the complete bypass list.
 
 ### Distribution
 
-Forwarded fees are sent to the fee collector module account. The distribution module allocates fee collector funds to validators and their delegators proportionally at `BeginBlock`. This distribution mechanism may be modified in future protocol upgrades.
-
-### Event
-
-```protobuf
-message EventFeeForwarded {
-  string from = 1;    // Address tokens were forwarded from
-  string amount = 2;  // Amount forwarded (e.g., "1000000utia")
-}
-```
-
-### Query
-
-```protobuf
-service Query {
-  rpc FeeAddress(QueryFeeAddressRequest) returns (QueryFeeAddressResponse);
-}
-
-message QueryFeeAddressRequest {}
-
-message QueryFeeAddressResponse {
-  string fee_address = 1;
-}
-```
+Forwarded fees are sent to the fee collector module account. The distribution module allocates fee collector funds to delegators proportionally at `BeginBlock`. Validators receive their share through their self-delegation. This distribution mechanism may be modified in future protocol upgrades.
 
 ### CLI Usage
 
 ```shell
 # Send tokens to the fee address (forwarded to protocol revenue in next block)
-celestia-appd tx bank send mykey celestia1feefeefeefeefeefeefeefeefeefeefe8pxlcf 1000000utia
+celestia-appd tx bank send mykey celestia18sjk23yldd9dg7j33sk24elwz2f06zt7ahx39y 1000000utia
 
-# Query the fee address
-celestia-appd query feeaddress fee-address
+# Query fee address balance
+celestia-appd query bank balances celestia18sjk23yldd9dg7j33sk24elwz2f06zt7ahx39y
+
+# Query fee address via auth module
+celestia-appd query auth module-account feeaddress
 ```
 
 ## Parameters
@@ -193,23 +180,25 @@ ProcessProposal strictly enforces fee forwarding to ensure:
 
 ### Other Design Decisions
 
-1. **No minimum balance threshold**: Forward any non-zero balance to minimize complexity. Very small amounts (e.g., 1 utia) trigger a fee forward tx with effective gas price ~0.00002 utia/gas (1 / 50,000). This is acceptable because protocol-injected txs skip min gas price validation, the contributor is still adding to protocol revenue, and block overhead is minimal (~100 bytes). Adding a threshold would delay forwarding and increase complexity.
-2. **One fee forward per block**: All contributions in the fee address are batched into a single MsgForwardFees tx (~100 bytes overhead)
+1. **No minimum balance threshold**: Forward any non-zero balance to minimize complexity. Very small amounts (e.g., 1 utia) trigger a protocol fee tx with effective gas price ~0.000025 utia/gas (1 / 40,000). This is acceptable because protocol-injected txs skip min gas price validation, the contributor is still adding to protocol revenue, and block overhead is minimal (~100 bytes). Adding a threshold would delay forwarding and increase complexity.
+2. **One protocol fee tx per block**: All contributions in the fee address are batched into a single `MsgPayProtocolFee` tx (~100 bytes overhead)
 3. **Unsigned transaction**: Validated via ProcessProposal fee balance check, not signature
-4. **Gas limit**: 50,000 (minimal - message handler only emits an event)
+4. **Gas limit**: 40,000 (minimal - message handler performs bank transfer only)
+5. **Module account over vanity address**: Using standard Cosmos SDK module account derivation ensures compatibility with existing tooling and avoids the need to maintain a custom vanity address.
 
 ## Backwards Compatibility
 
-This is a consensus-breaking change that requires a network upgrade. However, it is purely additive (new module) and does not affect existing functionality.
+This is a consensus-breaking change that requires a network upgrade. However, it is purely additive (new functionality) and does not affect existing functionality.
 
 ## Test Cases
 
 Test cases are available in the reference implementation:
 
-- Unit tests: `x/feeaddress/keeper_test.go`
-- Integration tests: `x/feeaddress/test/feeaddress_test.go`
+- Ante decorator tests: `app/ante/fee_address_test.go`, `app/ante/protocol_fee_test.go`
+- Integration tests: `app/feeaddress_test.go`, `app/protocol_fee_test.go`
+- Validation tests: `pkg/feeaddress/validation_test.go`
 
-Tests cover successful forwarding, wrong denom rejection, event emission, and ProcessProposal validation.
+Tests cover successful forwarding, wrong denom rejection, user submission rejection, and ProcessProposal validation.
 
 ## Security Considerations
 
@@ -219,9 +208,11 @@ Tests cover successful forwarding, wrong denom rejection, event emission, and Pr
 
 3. **Strict Enforcement**: Blocks that fail to forward non-zero balances are rejected, preventing proposers from withholding funds.
 
-4. **Spam Resistance**: The fee forward transaction is created by the block proposer in PrepareProposal, not sourced from the mempool. Users cannot prevent its inclusion by filling blocks with spam. A malicious proposer could omit it, but ProcessProposal would reject their block—tokens remain in the fee address until the next honest proposer.
+4. **Spam Resistance**: The protocol fee transaction is created by the block proposer in PrepareProposal, not sourced from the mempool. Users cannot prevent its inclusion by filling blocks with spam. A malicious proposer could omit it, but ProcessProposal would reject their block—tokens remain in the fee address until the next honest proposer.
 
-5. **Low-Value Contributions**: Sending very small amounts (e.g., 1 utia per block) is not an attack vector. Each contribution still adds to protocol revenue, the fee forward tx is minimal (~100 bytes), and gas price validation is intentionally skipped. The only observable effect is inflated transaction counts on dashboards, though revenue attribution remains accurate.
+5. **Low-Value Contributions**: Sending very small amounts (e.g., 1 utia per block) is not an attack vector. Each contribution still adds to protocol revenue, the protocol fee tx is minimal (~100 bytes), and gas price validation is intentionally skipped. The only observable effect is inflated transaction counts on dashboards, though revenue attribution remains accurate.
+
+6. **User Submission Rejection**: The `ProtocolFeeTerminatorDecorator` explicitly rejects any `MsgPayProtocolFee` transactions submitted by users, ensuring only protocol-injected transactions are processed.
 
 ## Reference Implementation
 


### PR DESCRIPTION
## Summary

Updates CIP-43 to match the final implementation in celestia-app PR #6441.

## Changes

- **Fee address**: Changed from vanity address to module account (`celestia18sjk23yldd9dg7j33sk24elwz2f06zt7ahx39y`)
- **Architecture**: Removed `x/feeaddress` module, types now in `pkg/feeaddress/`, ante handlers in `app/ante/`
- **Message**: Renamed `MsgForwardFees` → `MsgPayProtocolFee` with `from_address` field
- **Ante handler**: Renamed `FeeForwardDecorator` → `ProtocolFeeTerminatorDecorator`
- **Events**: Removed custom event section (bank module events suffice)
- **Query**: Removed query service (fee address accessible via `x/auth`)
- **Gas limit**: Updated from 50,000 to 40,000
- **Distribution**: Clarified fees go to delegators (validators receive via self-delegation)
- **Test paths**: Updated to reflect new file locations
- **CLI**: Updated examples with new fee address and removed query command

## Related

- Implementation PR: https://github.com/celestiaorg/celestia-app/pull/6441

🤖 Generated with [Claude Code](https://claude.com/claude-code)