### PR TITLE
docs(cip-43): clarify from_address refers to module account

### DIFF
--- a/cips/cip-043.md
+++ b/cips/cip-043.md
@@ -74,7 +74,7 @@ message MsgPayProtocolFee {
 }
 ```
 
-The `from_address` field is always set to the fee address module account. The message includes a signer annotation for SDK compatibility, but signature verification is skipped by the `ProtocolFeeTerminatorDecorator`. Validation happens via ProcessProposal checking that `tx fee == fee address balance`.
+The `from_address` field is always set to the [fee address module account](#fee-address). The message includes a signer annotation for SDK compatibility, but signature verification is skipped by the `ProtocolFeeTerminatorDecorator`. Validation happens via ProcessProposal checking that `tx fee == fee address balance`.
 
 ### Validation Rules
 


### PR DESCRIPTION
## Summary
- Clarifies that `from_address` is set to the fee address **module account**

Addresses review comment: https://github.com/celestiaorg/CIPs/pull/381#discussion_r2722630483

## Test plan
- [x] Verified markdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)