### PR TITLE
docs: adds cips deepwiki badge to allow indexing of CIPs on deepwiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Celestia Improvement Proposals (CIPs)
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/celestiaorg/cips)
+
 See [/cips/README.md](./cips/README.md) for an overview of the CIP process.
 
 See the [WGs directory](./cips/wgs/README.md) for Working Groups within the CIP process.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
