### PR TITLE
docs: update v7 CIPs status to In Review

### DIFF
--- a/cips/cip-043.md
+++ b/cips/cip-043.md
@@ -4,7 +4,7 @@
 | description | Forward TIA tokens to protocol revenue via a dedicated fee address |
 | author | Manav Aggarwal ([@Manav-Aggarwal](https://github.com/Manav-Aggarwal)) |
 | discussions-to | <https://forum.celestia.org/t/cip-add-burn-module/2216> |
-| status | Draft |
+| status | In Review |
 | type | Standards Track |
 | category | Core |
 | created | 2026-01-14 |

--- a/cips/cip-044.md
+++ b/cips/cip-044.md
@@ -4,7 +4,7 @@
 | description    | Increase maximum validator commission to 60% and minimum commission to 20% |
 | author         | Callum Waters ([@cmwaters](https://github.com/cmwaters))                   |
 | discussions-to | <https://forum.celestia.org/t/cip-adjust-validator-commission-bounds/2217> |
-| status         | Draft                                                                      |
+| status         | In Review                                                                  |
 | type           | Standards Track                                                            |
 | category       | Core                                                                       |
 | created        | 2026-01-14                                                                 |

--- a/cips/cip-045.md
+++ b/cips/cip-045.md
@@ -4,7 +4,7 @@
 | description | Enable cross-chain token forwarding via Hyperlane warp routes |
 | author | Manav Aggarwal ([@Manav-Aggarwal](https://github.com/Manav-Aggarwal)) |
 | discussions-to | <https://forum.celestia.org/t/cip-add-forwarding-module/2218> |
-| status | Draft |
+| status | In Review |
 | type | Standards Track |
 | category | Core |
 | created | 2026-01-19 |

--- a/cips/cip-046.md
+++ b/cips/cip-046.md
@@ -4,7 +4,7 @@
 | description | Proof-based Hyperlane ISM using Groth16 verification |
 | author | Manav Aggarwal ([@Manav-Aggarwal](https://github.com/Manav-Aggarwal)) |
 | discussions-to | <https://forum.celestia.org/t/cip-add-hyperlane-zk-ism-module/2219> |
-| status | Draft |
+| status | In Review |
 | type | Standards Track |
 | category | Core |
 | created | 2026-01-20 |

--- a/cips/cip-047.md
+++ b/cips/cip-047.md
@@ -4,7 +4,7 @@
 | description    | Reference CIPs included in the Hibiscus (v7) Network Upgrade                                   |
 | author         | [@rootulp](https://github.com/rootulp)                                                         |
 | discussions-to | <https://forum.celestia.org/t/cip-v7-network-upgrade/2220>                                     |
-| status         | Draft                                                                                          |
+| status         | In Review                                                                                      |
 | type           | Meta                                                                                           |
 | created        | 2026-01-21                                                                                     |
 | requires       | [CIP-43](./cip-043.md), [CIP-44](./cip-044.md), [CIP-45](./cip-045.md), [CIP-46](./cip-046.md) |


### PR DESCRIPTION
## Summary
- Update CIP-43, CIP-44, CIP-45, CIP-46, and CIP-47 status from Draft to In Review
- These CIPs are all part of the Hibiscus (v7) network upgrade

## Test plan
- [x] Verify status field updated correctly in all 5 CIP files

🤖 Generated with [Claude Code](https://claude.com/claude-code)