### PR TITLE
docs: remove feeaddress from v7

### DIFF
--- a/cips/cip-047.md
+++ b/cips/cip-047.md
@@ -17,7 +17,6 @@ This Meta CIP lists the CIPs included in the Hibiscus (v7) network upgrade.
 
 ### Included CIPs
 
-- [CIP-43](./cip-043.md): Fee address module
 - [CIP-44](./cip-044.md): Adjust Validator Commission Bounds
 - [CIP-45](./cip-045.md): Forwarding Module
 - [CIP-46](./cip-046.md): ZK Interchain Security Module


### PR DESCRIPTION
The feeaddress implementation in celestia-app was rushed and entirely AI written. Since it isn't critical for the interop team to have it included in v7, we're reverting it.