### PR TITLE
chore: gitignore claude settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ cips/*.html
 
 # WGs - same note as above
 cips/wgs/**/*.html
+
+# Claude Code local settings
+.claude/*.local.json


### PR DESCRIPTION
Claude Code adds entries to a local file named `.claude/settings.local.json` and we don't want that file included in version control