### PR TITLE
[codex] Finalize v7 CIPs and add v8 CIP

### DIFF
--- a/cips/README.md
+++ b/cips/README.md
@@ -97,7 +97,7 @@ Read [CIP-1](./cip-001.md) for information on the CIP process.
 | [44](./cip-044.md) | Adjust Validator Commission Bounds                                           | [@cmwaters](https://github.com/cmwaters)                                                                                                                                     |
 | [45](./cip-045.md) | Forwarding Module                                                            | [@Manav-Aggarwal](https://github.com/Manav-Aggarwal)                                                                                                                         |
 | [46](./cip-046.md) | ZK Interchain Security Module                                                | [@Manav-Aggarwal](https://github.com/Manav-Aggarwal)                                                                                                                         |
-| [47](./cip-047.md) | Hibiscus (v7) Network Upgrade                                                | [@rootulp](https://github.com/rootulp)                                                                                                                                       |
+| [47](./cip-047.md) | v8 Network Upgrade                                                           | [@rootulp](https://github.com/rootulp)                                                                                                                                       |
 | [48](./cip-048.md) | Lower block time to 3 seconds                                                | [@rootulp](https://github.com/rootulp)                                                                                                                                       |
 
 ## Contributing

--- a/cips/README.md
+++ b/cips/README.md
@@ -97,8 +97,9 @@ Read [CIP-1](./cip-001.md) for information on the CIP process.
 | [44](./cip-044.md) | Adjust Validator Commission Bounds                                           | [@cmwaters](https://github.com/cmwaters)                                                                                                                                     |
 | [45](./cip-045.md) | Forwarding Module                                                            | [@Manav-Aggarwal](https://github.com/Manav-Aggarwal)                                                                                                                         |
 | [46](./cip-046.md) | ZK Interchain Security Module                                                | [@Manav-Aggarwal](https://github.com/Manav-Aggarwal)                                                                                                                         |
-| [47](./cip-047.md) | Hibiscus (v8) Network Upgrade                                                | [@rootulp](https://github.com/rootulp)                                                                                                                                       |
+| [47](./cip-047.md) | Hibiscus (v7) Network Upgrade                                                | [@rootulp](https://github.com/rootulp)                                                                                                                                       |
 | [48](./cip-048.md) | Lower block time to 3 seconds                                                | [@rootulp](https://github.com/rootulp)                                                                                                                                       |
+| [49](./cip-049.md) | v8 Network Upgrade                                                           | [@rootulp](https://github.com/rootulp)                                                                                                                                       |
 
 ## Contributing
 

--- a/cips/README.md
+++ b/cips/README.md
@@ -97,7 +97,7 @@ Read [CIP-1](./cip-001.md) for information on the CIP process.
 | [44](./cip-044.md) | Adjust Validator Commission Bounds                                           | [@cmwaters](https://github.com/cmwaters)                                                                                                                                     |
 | [45](./cip-045.md) | Forwarding Module                                                            | [@Manav-Aggarwal](https://github.com/Manav-Aggarwal)                                                                                                                         |
 | [46](./cip-046.md) | ZK Interchain Security Module                                                | [@Manav-Aggarwal](https://github.com/Manav-Aggarwal)                                                                                                                         |
-| [47](./cip-047.md) | v8 Network Upgrade                                                           | [@rootulp](https://github.com/rootulp)                                                                                                                                       |
+| [47](./cip-047.md) | Hibiscus (v8) Network Upgrade                                                | [@rootulp](https://github.com/rootulp)                                                                                                                                       |
 | [48](./cip-048.md) | Lower block time to 3 seconds                                                | [@rootulp](https://github.com/rootulp)                                                                                                                                       |
 
 ## Contributing

--- a/cips/SUMMARY.md
+++ b/cips/SUMMARY.md
@@ -51,6 +51,7 @@
   - [CIP-46](./cip-046.md)
   - [CIP-47](./cip-047.md)
   - [CIP-48](./cip-048.md)
+  - [CIP-49](./cip-049.md)
 
 - [Core Devs Call notes](./notes/README.md)
   - [CDC #14](./notes/cdc-14.md)

--- a/cips/cip-044.md
+++ b/cips/cip-044.md
@@ -4,8 +4,7 @@
 | description    | Increase maximum validator commission to 60% and minimum commission to 20% |
 | author         | Callum Waters ([@cmwaters](https://github.com/cmwaters))                   |
 | discussions-to | <https://forum.celestia.org/t/cip-adjust-validator-commission-bounds/2217> |
-| status         | Last Call                                                                  |
-| last-call-deadline | 2026-03-03                                                               |
+| status         | Final                                                                      |
 | type           | Standards Track                                                            |
 | category       | Core                                                                       |
 | created        | 2026-01-14                                                                 |

--- a/cips/cip-045.md
+++ b/cips/cip-045.md
@@ -4,8 +4,7 @@
 | description | Enable cross-chain token forwarding via Hyperlane warp routes |
 | author | Manav Aggarwal ([@Manav-Aggarwal](https://github.com/Manav-Aggarwal)) |
 | discussions-to | <https://forum.celestia.org/t/cip-add-forwarding-module/2218> |
-| status | Last Call |
-| last-call-deadline | 2026-03-03 |
+| status | Final |
 | type | Standards Track |
 | category | Core |
 | created | 2026-01-19 |

--- a/cips/cip-046.md
+++ b/cips/cip-046.md
@@ -4,8 +4,7 @@
 | description | Proof-based Hyperlane ISM using Groth16 verification |
 | author | Manav Aggarwal ([@Manav-Aggarwal](https://github.com/Manav-Aggarwal)) |
 | discussions-to | <https://forum.celestia.org/t/cip-add-hyperlane-zk-ism-module/2219> |
-| status | Last Call |
-| last-call-deadline | 2026-03-03 |
+| status | Final |
 | type | Standards Track |
 | category | Core |
 | created | 2026-01-20 |

--- a/cips/cip-047.md
+++ b/cips/cip-047.md
@@ -1,7 +1,7 @@
 | cip            | 47                                                                                             |
 |----------------|------------------------------------------------------------------------------------------------|
-| title          | v8 Network Upgrade                                                                             |
-| description    | Reference CIPs included in the v8 Network Upgrade                                              |
+| title          | Hibiscus (v8) Network Upgrade                                                                  |
+| description    | Reference CIPs included in the Hibiscus (v8) Network Upgrade                                   |
 | author         | [@rootulp](https://github.com/rootulp)                                                         |
 | discussions-to | <https://forum.celestia.org/t/cip-v7-network-upgrade/2220>                                     |
 | status         | Final                                                                                          |
@@ -11,7 +11,7 @@
 
 ## Abstract
 
-This Meta CIP lists the CIPs included in the v8 network upgrade. The upgrade was originally planned as Hibiscus (v7), but is now scheduled as v8 because a bug was discovered in v7 on testnets.
+This Meta CIP lists the CIPs included in the Hibiscus (v8) network upgrade. The Hibiscus upgrade was originally planned for v7, but is now scheduled as v8 because a bug was discovered in v7 on testnets.
 
 ## Specification
 
@@ -25,7 +25,7 @@ All of the above CIPs are state breaking, and thus require a breaking network up
 
 ## Rationale
 
-This CIP provides a complete list of breaking changes for the v8 network upgrade, along with links to those specs.
+This CIP provides a complete list of breaking changes for the Hibiscus (v8) network upgrade, along with links to those specs.
 
 ## Security Considerations
 

--- a/cips/cip-047.md
+++ b/cips/cip-047.md
@@ -1,7 +1,7 @@
 | cip            | 47                                                                                             |
 |----------------|------------------------------------------------------------------------------------------------|
-| title          | Hibiscus (v8) Network Upgrade                                                                  |
-| description    | Reference CIPs included in the Hibiscus (v8) Network Upgrade                                   |
+| title          | Hibiscus (v7) Network Upgrade                                                                  |
+| description    | Reference CIPs included in the Hibiscus (v7) Network Upgrade                                   |
 | author         | [@rootulp](https://github.com/rootulp)                                                         |
 | discussions-to | <https://forum.celestia.org/t/cip-v7-network-upgrade/2220>                                     |
 | status         | Final                                                                                          |
@@ -11,7 +11,7 @@
 
 ## Abstract
 
-This Meta CIP lists the CIPs included in the Hibiscus (v8) network upgrade. The Hibiscus upgrade was originally planned for v7, but is now scheduled as v8 because a bug was discovered in v7 on testnets.
+This Meta CIP lists the CIPs included in the Hibiscus (v7) network upgrade. Hibiscus included the changes listed below, but was not activated on Mainnet Beta after an `x/forwarding` bug was discovered during testnet rollout. The same changes are carried forward for Mainnet Beta in [CIP-49](./cip-049.md).
 
 ## Specification
 
@@ -25,7 +25,7 @@ All of the above CIPs are state breaking, and thus require a breaking network up
 
 ## Rationale
 
-This CIP provides a complete list of breaking changes for the Hibiscus (v8) network upgrade, along with links to those specs.
+This CIP provides a complete list of breaking changes for the Hibiscus (v7) network upgrade, along with links to those specs. It remains separate from the v8 network upgrade so that the Hibiscus name continues to refer to v7 and the Mainnet Beta follow-up upgrade can be tracked by version number.
 
 ## Security Considerations
 

--- a/cips/cip-047.md
+++ b/cips/cip-047.md
@@ -1,18 +1,17 @@
 | cip            | 47                                                                                             |
 |----------------|------------------------------------------------------------------------------------------------|
-| title          | Hibiscus (v7) Network Upgrade                                                                  |
-| description    | Reference CIPs included in the Hibiscus (v7) Network Upgrade                                   |
+| title          | v8 Network Upgrade                                                                             |
+| description    | Reference CIPs included in the v8 Network Upgrade                                              |
 | author         | [@rootulp](https://github.com/rootulp)                                                         |
 | discussions-to | <https://forum.celestia.org/t/cip-v7-network-upgrade/2220>                                     |
-| status         | Last Call                                                                                      |
-| last-call-deadline | 2026-03-03                                                                                 |
+| status         | Final                                                                                          |
 | type           | Meta                                                                                           |
 | created        | 2026-01-21                                                                                     |
 | requires       | [CIP-44](./cip-044.md), [CIP-45](./cip-045.md), [CIP-46](./cip-046.md) |
 
 ## Abstract
 
-This Meta CIP lists the CIPs included in the Hibiscus (v7) network upgrade.
+This Meta CIP lists the CIPs included in the v8 network upgrade. The upgrade was originally planned as Hibiscus (v7), but is now scheduled as v8 because a bug was discovered in v7 on testnets.
 
 ## Specification
 
@@ -26,7 +25,7 @@ All of the above CIPs are state breaking, and thus require a breaking network up
 
 ## Rationale
 
-This CIP provides a complete list of breaking changes for the Hibiscus (v7) network upgrade, along with links to those specs.
+This CIP provides a complete list of breaking changes for the v8 network upgrade, along with links to those specs.
 
 ## Security Considerations
 

--- a/cips/cip-049.md
+++ b/cips/cip-049.md
@@ -1,0 +1,36 @@
+| cip            | 49                                                                                             |
+|----------------|------------------------------------------------------------------------------------------------|
+| title          | v8 Network Upgrade                                                                             |
+| description    | Reference CIPs included in the v8 Network Upgrade                                              |
+| author         | [@rootulp](https://github.com/rootulp)                                                         |
+| discussions-to | <https://github.com/celestiaorg/CIPs/pull/396>                                                 |
+| status         | Final                                                                                          |
+| type           | Meta                                                                                           |
+| created        | 2026-04-30                                                                                     |
+| requires       | [CIP-44](./cip-044.md), [CIP-45](./cip-045.md), [CIP-46](./cip-046.md) |
+
+## Abstract
+
+This Meta CIP lists the CIPs included in the v8 network upgrade. v8 carries forward the same state-breaking changes that were included in the Hibiscus (v7) network upgrade, after v7 was prevented from activating on Mainnet Beta due to an `x/forwarding` bug discovered during testnet rollout.
+
+## Specification
+
+### Included CIPs
+
+- [CIP-44](./cip-044.md): Adjust Validator Commission Bounds
+- [CIP-45](./cip-045.md): Forwarding Module
+- [CIP-46](./cip-046.md): ZK Interchain Security Module
+
+All of the above CIPs are state breaking, and thus require a breaking network upgrade.
+
+## Rationale
+
+This CIP provides a complete list of breaking changes for the v8 network upgrade, along with links to those specs. A separate Meta CIP avoids applying the Hibiscus name to both v7 and v8 while preserving the historical record that v7 contained the same CIPs.
+
+## Security Considerations
+
+This CIP does not have additional security concerns beyond what is already discussed in each of the listed specs.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://github.com/celestiaorg/CIPs/blob/main/LICENSE).

--- a/cips/cip-049.md
+++ b/cips/cip-049.md
@@ -2,7 +2,7 @@
 |----------------|------------------------------------------------------------------------------------------------|
 | title          | v8 Network Upgrade                                                                             |
 | description    | Reference CIPs included in the v8 Network Upgrade                                              |
-| author         | [@rootulp](https://github.com/rootulp)                                                         |
+| author         | [@jcstein](https://github.com/jcstein)                                                         |
 | discussions-to | <https://github.com/celestiaorg/CIPs/pull/396>                                                 |
 | status         | Draft                                                                                          |
 | type           | Meta                                                                                           |

--- a/cips/cip-049.md
+++ b/cips/cip-049.md
@@ -4,7 +4,7 @@
 | description    | Reference CIPs included in the v8 Network Upgrade                                              |
 | author         | [@rootulp](https://github.com/rootulp)                                                         |
 | discussions-to | <https://github.com/celestiaorg/CIPs/pull/396>                                                 |
-| status         | Final                                                                                          |
+| status         | Draft                                                                                          |
 | type           | Meta                                                                                           |
 | created        | 2026-04-30                                                                                     |
 | requires       | [CIP-44](./cip-044.md), [CIP-45](./cip-045.md), [CIP-46](./cip-046.md) |


### PR DESCRIPTION
## Summary

- Keep CIP-47 as the Hibiscus (v7) Network Upgrade and note that v7 did not activate on Mainnet Beta after an `x/forwarding` bug was discovered during testnet rollout.
- Add CIP-49 as the separate Draft v8 Network Upgrade Meta CIP, carrying forward CIP-44, CIP-45, and CIP-46 without reusing the Hibiscus name.
- Move CIP-44, CIP-45, CIP-46, and CIP-47 from Last Call to Final and remove their last-call-deadline metadata.
- Add CIP-49 to the CIP overview table and mdBook summary.

## Validation

- `npx markdownlint-cli@0.39.0 --config .markdownlint.yaml cips/cip-044.md cips/cip-045.md cips/cip-046.md cips/cip-047.md cips/cip-049.md cips/README.md cips/SUMMARY.md`
- `npx markdownlint-cli@0.39.0 --config .markdownlint.yaml cips/cip-049.md cips/README.md cips/SUMMARY.md`
- `git diff --check`
