### PR TITLE
[codex] Add v9 network upgrade CIP

### DIFF
--- a/cips/README.md
+++ b/cips/README.md
@@ -100,6 +100,7 @@ Read [CIP-1](./cip-001.md) for information on the CIP process.
 | [47](./cip-047.md) | Hibiscus (v7) Network Upgrade                                                | [@rootulp](https://github.com/rootulp)                                                                                                                                       |
 | [48](./cip-048.md) | Lower block time to 3 seconds                                                | [@rootulp](https://github.com/rootulp)                                                                                                                                       |
 | [49](./cip-049.md) | v8 Network Upgrade                                                           | [@jcstein](https://github.com/jcstein)                                                                                                                                       |
+| [50](./cip-050.md) | v9 Network Upgrade                                                           | [@jcstein](https://github.com/jcstein)                                                                                                                                       |
 
 ## Contributing
 

--- a/cips/SUMMARY.md
+++ b/cips/SUMMARY.md
@@ -52,6 +52,7 @@
   - [CIP-47](./cip-047.md)
   - [CIP-48](./cip-048.md)
   - [CIP-49](./cip-049.md)
+  - [CIP-50](./cip-050.md)
 
 - [Core Devs Call notes](./notes/README.md)
   - [CDC #14](./notes/cdc-14.md)

--- a/cips/cip-050.md
+++ b/cips/cip-050.md
@@ -3,11 +3,11 @@
 | title          | v9 Network Upgrade                                                                             |
 | description    | Reference CIPs and parameter settings included in the v9 Network Upgrade                       |
 | author         | [@jcstein](https://github.com/jcstein)                                                         |
-| discussions-to | <https://github.com/celestiaorg/celestia-app/releases/tag/v9.0.4>                              |
+| discussions-to | <https://github.com/celestiaorg/CIPs/pull/399>                                                 |
 | status         | Draft                                                                                          |
 | type           | Meta                                                                                           |
 | created        | 2026-06-18                                                                                     |
-| requires       | [CIP-48](./cip-048.md)                                                                         |
+| requires       | [CIP-48](./cip-048.md), [CIP-38](./cip-038.md)                                                 |
 
 ## Abstract
 
@@ -31,7 +31,7 @@ The v9 upgrade handler MUST set the following target values at the upgrade heigh
 | `consensus.block.MaxBytes` | 32 MiB | Maximum protobuf encoded block size accepted by consensus |
 | `blob.GovMaxSquareSize` | 256 | Governance parameter for the maximum original data square size |
 | `consensus.evidence.MaxAgeNumBlocks` | 559,940 | Evidence age window in blocks, scaled to preserve the same wall-clock duration under faster block times |
-| `ibc.ConnectionGenesis.MaxExpectedTimePerBlock` | 13 seconds | Maximum expected time per block used by IBC connection verification |
+| `ibc.ConnectionGenesis.Params.MaxExpectedTimePerBlock` | 13 seconds | Maximum expected time per block used by IBC connection verification |
 
 The timeout, upgrade-delay, evidence-window, and IBC changes are specified in [CIP-48](./cip-048.md). The `consensus.block.MaxBytes` and `blob.GovMaxSquareSize` values set the Mainnet Beta capacity envelope for the v9 release while remaining within the hard protocol limits introduced by [CIP-38](./cip-038.md).
 

--- a/cips/cip-050.md
+++ b/cips/cip-050.md
@@ -1,0 +1,66 @@
+| cip            | 50                                                                                             |
+|----------------|------------------------------------------------------------------------------------------------|
+| title          | v9 Network Upgrade                                                                             |
+| description    | Reference CIPs and parameter settings included in the v9 Network Upgrade                       |
+| author         | [@jcstein](https://github.com/jcstein)                                                         |
+| discussions-to | <https://github.com/celestiaorg/celestia-app/releases/tag/v9.0.4>                              |
+| status         | Draft                                                                                          |
+| type           | Meta                                                                                           |
+| created        | 2026-06-18                                                                                     |
+| requires       | [CIP-48](./cip-048.md)                                                                         |
+
+## Abstract
+
+This Meta CIP lists the protocol changes included in the v9 network upgrade for Celestia Mainnet Beta. The primary change is [CIP-48](./cip-048.md), which reduces the target block time from 6 seconds to approximately 3 seconds. The upgrade also applies the v9 upgrade handler parameter settings required to support the faster block cadence and updated Mainnet Beta operating envelope.
+
+## Specification
+
+### Included CIPs
+
+- [CIP-48](./cip-048.md): Lower block time to 3 seconds
+
+CIP-48 is state breaking and thus requires a breaking network upgrade.
+
+### Upgrade handler parameter settings
+
+The v9 upgrade handler MUST set the following target values at the upgrade height. Some governance-modifiable parameters may already match these values before activation; the handler reaffirms the v9 release envelope.
+
+| Parameter | v9 value | Description |
+| --------- | -------- | ----------- |
+| `consensus.Version.AppVersion` | 9 | Application version used to determine protocol rules for a given height |
+| `consensus.block.MaxBytes` | 32 MiB | Maximum protobuf encoded block size accepted by consensus |
+| `blob.GovMaxSquareSize` | 256 | Governance parameter for the maximum original data square size |
+| `consensus.evidence.MaxAgeNumBlocks` | 559,940 | Evidence age window in blocks, scaled to preserve the same wall-clock duration under faster block times |
+| `ibc.ConnectionGenesis.MaxExpectedTimePerBlock` | 13 seconds | Maximum expected time per block used by IBC connection verification |
+
+The timeout, upgrade-delay, evidence-window, and IBC changes are specified in [CIP-48](./cip-048.md). The `consensus.block.MaxBytes` and `blob.GovMaxSquareSize` values set the Mainnet Beta capacity envelope for the v9 release while remaining within the hard protocol limits introduced by [CIP-38](./cip-038.md).
+
+### Operator configuration
+
+The v9 release also changes node behavior around `min-retain-blocks`: non-zero values enable pruning, and archival nodes must keep `min-retain-blocks = 0`. This is operational guidance for node configuration and is not an additional protocol CIP included in the v9 network upgrade.
+
+## Rationale
+
+This CIP provides a complete list of the CIPs and upgrade-handler parameter settings included in the v9 network upgrade. A separate Meta CIP makes the upgrade record easy to audit without duplicating the detailed block-time specification already maintained in CIP-48.
+
+The v9 release is primarily about reducing confirmation latency by moving Celestia from 6-second blocks to approximately 3-second blocks. The upgrade-handler parameter settings preserve safety-relevant wall-clock windows after the block cadence changes and set the Mainnet Beta block and square-size parameters used by the release.
+
+## Backwards Compatibility
+
+This upgrade is not backwards compatible. Consensus nodes must upgrade to a v9-compatible `celestia-app` release before the activation height. Nodes that continue running older software will not follow the post-upgrade chain.
+
+Client applications and tooling that assume a 6-second block time SHOULD be updated to use the v9 block-time assumptions from CIP-48.
+
+## Reference Implementation
+
+The reference implementation is [celestia-app v9.0.4](https://github.com/celestiaorg/celestia-app/releases/tag/v9.0.4).
+
+## Security Considerations
+
+This CIP does not have additional security concerns beyond those discussed in CIP-48 and CIP-38.
+
+Validators and node operators should still account for the operational impact of the v9 release. Faster block times increase sensitivity to validator latency and node performance. Operators using non-zero `min-retain-blocks` should also be aware that pruning may run on startup and can take time on nodes with a large historical backlog.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://github.com/celestiaorg/CIPs/blob/main/LICENSE).


### PR DESCRIPTION
## Summary

- Add CIP-50 as a draft Meta CIP for the v9 network upgrade
- Reference CIP-48 as the included protocol CIP for the ~3s block-time reduction
- Document v9 upgrade-handler parameter settings and note `min-retain-blocks` as operator guidance
- Add CIP-50 to the book summary and CIP overview table

## Validation

- `npx --yes markdownlint-cli --config .markdownlint.yaml 'cips/cip-050.md' 'cips/SUMMARY.md' 'cips/README.md'`
- `git diff --cached --check`