### PR TITLE
Add Fibre Protocol CIP

### DIFF
--- a/cips/README.md
+++ b/cips/README.md
@@ -101,6 +101,7 @@ Read [CIP-1](./cip-001.md) for information on the CIP process.
 | [48](./cip-048.md) | Lower block time to 3 seconds                                                | [@rootulp](https://github.com/rootulp)                                                                                                                                       |
 | [49](./cip-049.md) | v8 Network Upgrade                                                           | [@jcstein](https://github.com/jcstein)                                                                                                                                       |
 | [50](./cip-050.md) | v9 Network Upgrade                                                           | [@jcstein](https://github.com/jcstein)                                                                                                                                       |
+| [51](./cip-051.md) | Fibre Protocol                                                               | [@rach-id](https://github.com/rach-id)                                                                                                                                       |
 
 ## Contributing
 

--- a/cips/SUMMARY.md
+++ b/cips/SUMMARY.md
@@ -53,6 +53,7 @@
   - [CIP-48](./cip-048.md)
   - [CIP-49](./cip-049.md)
   - [CIP-50](./cip-050.md)
+  - [CIP-51](./cip-051.md)
 
 - [Core Devs Call notes](./notes/README.md)
   - [CDC #14](./notes/cdc-14.md)

--- a/cips/cip-051.md
+++ b/cips/cip-051.md
@@ -1,0 +1,111 @@
+| cip            | 51                                                                  |
+|----------------|---------------------------------------------------------------------|
+| title          | Fibre Protocol                                                      |
+| description    | Introduce Fibre for validator-operated off-chain blob availability. |
+| author         | [@rach-id](https://github.com/rach-id)                              |
+| status         | Implemented                                                         |
+| type           | Standards Track                                                     |
+| category       | Core, Data Availability, Networking                                 |
+| created        | 2026-06-30                                                          |
+
+## Abstract
+
+This CIP proposes Fibre, a validator-operated protocol for publishing blobs whose payload bytes are stored and served outside the normal block data path. Fibre keeps an on-chain record of publication through `MsgPayForFibre` transactions and synthesized system blobs that commit to the Fibre blob version and commitment.
+
+Fibre adds a blob encoding, validator shard assignment, a validator gRPC service, validator endpoint registration, and an `x/fibre` escrow and settlement module. These components allow clients to upload erasure-coded blob shards to validators, collect validator signatures, settle payment on-chain, and allow readers to reconstruct the blob from validator-served shards.
+
+## Motivation
+
+Celestia's normal blob path stores payload data directly in the original data square. Fibre provides a complementary path for higher-throughput blob publication by committing to blob data on-chain while distributing the payload through validator-operated services.
+
+This reduces pressure on the block data path for large blobs while preserving an on-chain commitment, fee settlement path, and deterministic verification rules for clients and validators.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+Fibre MUST be implemented according to the versioned Fibre specifications in the reference implementation:
+
+- <https://github.com/celestiaorg/celestia-app/blob/main/specs/src/fibre_encoding.md>
+- <https://github.com/celestiaorg/celestia-app/blob/main/specs/src/fibre_module.md>
+- <https://github.com/celestiaorg/celestia-app/blob/main/specs/src/fibre_client.md>
+- <https://github.com/celestiaorg/celestia-app/blob/main/specs/src/fibre_server.md>
+- <https://github.com/celestiaorg/celestia-app/blob/main/specs/src/fibre_registry_module.md>
+
+At a high level, Fibre introduces:
+
+1. A Fibre blob encoding and commitment scheme.
+2. Deterministic assignment of encoded blob shards to validators.
+3. A validator-operated Fibre gRPC service for shard upload and download.
+4. Validator-endorsed TLS identity for Fibre gRPC connections.
+5. The `x/fibre` module for escrow accounts, delayed withdrawals, payment-promise settlement, timeout settlement, replay protection, parameters, messages, and queries.
+6. The `x/valaddr` module path for validator Fibre provider host registration.
+7. Data-square construction rules for accepted standalone `MsgPayForFibre` transactions and synthesized Fibre system blobs.
+
+Fibre payload bytes MUST NOT be stored in the original data square through the normal blob payload path. An accepted Fibre publication MUST be represented on-chain by a standalone `MsgPayForFibre` transaction and a synthesized system blob containing the Fibre blob version and commitment.
+
+Fibre is state-breaking and MUST be activated as part of a coordinated network upgrade. The upgrade MUST enable the `x/fibre` module, the validator provider registry, Fibre data-square construction, and Fibre-compatible binaries.
+
+## Parameters
+
+The following `x/fibre` parameters are introduced:
+
+| Parameter | Proposed value | Description | Changeable via Governance |
+|-----------|----------------|-------------|---------------------------|
+| `fibre.GasPerBlobByte` | `1` | Positive stored parameter. The v0 payment formula does not use this value. | Yes |
+| `fibre.WithdrawalDelay` | `24h` | Delay before escrow withdrawals become executable; also bounds accepted payment-promise age. | Yes |
+| `fibre.PaymentPromiseTimeout` | `1h` | Time after which a payment promise can be settled by timeout. | Yes |
+| `fibre.PaymentPromiseRetentionWindow` | `24h` | Time processed-payment records are retained for replay protection. | Yes |
+| `fibre.PaymentPromiseHeightWindow` | `1000` blocks | Maximum normal payment-promise height lag behind current height. | Yes |
+
+The following hardcoded Fibre constants are introduced:
+
+| Constant | Proposed value | Description | Changeable via Governance |
+|----------|----------------|-------------|---------------------------|
+| `MaxPayForFibreMessages` | `200` | Maximum accepted PayForFibre messages per block. | No |
+| `PFBFibreGasFixedCost` | `650000` | Fixed gas component charged per Fibre blob. | No |
+| `PFBFibreGasPerChunk` | `45000` | Gas charged per 256 KiB upload-size chunk. | No |
+| `PFBFibreChunkSize` | `262144` bytes | Chunk size used by the Fibre payment formula. | No |
+
+## Rationale
+
+Fibre keeps a compact on-chain record while moving blob payload transfer to validator-operated services. This allows Celestia to support a higher-throughput publication path without requiring every Fibre payload byte to be included in the normal block data square.
+
+Escrow-backed payment promises let validators verify payment before storing shards. Validator signatures confirm that assigned shards were accepted by validators, while timeout settlement prevents an escrow owner from avoiding payment indefinitely after creating a valid promise.
+
+Routing Fibre payments to the fee collector mirrors regular data-availability fee distribution and avoids making settlement depend on the exact validators that signed a payment promise.
+
+## Backwards Compatibility
+
+This change is not backwards compatible. Consensus nodes must upgrade to Fibre-compatible software before the activation height. Older nodes will not understand the new modules, messages, and Fibre data-square construction rules.
+
+Existing normal blob submission remains supported. Fibre introduces an additional publication path rather than replacing `MsgPayForBlobs`.
+
+Clients and indexers that parse data-square contents SHOULD be updated to recognize Fibre PayForFibre transactions and synthesized Fibre system blobs.
+
+## Test Cases
+
+The reference implementation includes tests for Fibre encoding, shard assignment, upload and download verification, escrow settlement, timeout settlement, validator host registration, data-square construction, and validator-endorsed TLS.
+
+## Reference Implementation
+
+The reference implementation is the Fibre implementation in `celestia-app`:
+
+- <https://github.com/celestiaorg/celestia-app/tree/main/fibre>
+- <https://github.com/celestiaorg/celestia-app/tree/main/x/fibre>
+- <https://github.com/celestiaorg/celestia-app/tree/main/x/valaddr>
+- <https://github.com/celestiaorg/celestia-app/tree/main/proto/celestia/fibre/v1>
+
+## Security Considerations
+
+Fibre availability depends on enough validator-operated Fibre servers storing and serving assigned shards until the payment-promise expiration time. If too many assigned validators are unavailable, pruning early, misconfigured, or unreachable, readers may fail to reconstruct the blob even though the on-chain commitment exists.
+
+Validators MUST verify payment promises and shard assignments before signing. A validator signature means the validator accepted and stored its assigned shard. Signing without storing weakens Fibre availability.
+
+The Fibre commitment binds bytes, not application meaning. Applications that consume Fibre blobs remain responsible for checking namespace, signer, and application-level validity.
+
+Fibre gRPC endpoints are exposed validator services. Servers MUST enforce message-size limits, proof verification, assignment checks, and validator-endorsed TLS identity verification. Clients MUST authenticate the server as the intended validator before uploading shards or accepting downloaded shards.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://github.com/celestiaorg/CIPs/blob/main/LICENSE).


### PR DESCRIPTION
## Summary

- Adds CIP-51 for the Fibre Protocol.
- Updates the CIP README and mdBook summary indexes.

## Validation

- markdownlint --config .markdownlint.yaml cips/cip-051.md cips/README.md cips/SUMMARY.md

Closes celestiaorg/celestia-app#6621
Closes PROTOCO-1065