### PR TITLE
docs: add v10 CIP

### DIFF
--- a/cips/README.md
+++ b/cips/README.md
@@ -102,6 +102,7 @@ Read [CIP-1](./cip-001.md) for information on the CIP process.
 | [49](./cip-049.md) | v8 Network Upgrade                                                           | [@jcstein](https://github.com/jcstein)                                                                                                                                       |
 | [50](./cip-050.md) | v9 Network Upgrade                                                           | [@jcstein](https://github.com/jcstein)                                                                                                                                       |
 | [51](./cip-051.md) | Fibre Protocol                                                               | [@rach-id](https://github.com/rach-id)                                                                                                                                       |
+| [52](./cip-052.md) | v10 Network Upgrade                                                          | [@rach-id](https://github.com/rach-id)                                                                                                                                       |
 
 ## Contributing
 

--- a/cips/SUMMARY.md
+++ b/cips/SUMMARY.md
@@ -54,6 +54,7 @@
   - [CIP-49](./cip-049.md)
   - [CIP-50](./cip-050.md)
   - [CIP-51](./cip-051.md)
+  - [CIP-52](./cip-052.md)
 
 - [Core Devs Call notes](./notes/README.md)
   - [CDC #14](./notes/cdc-14.md)

--- a/cips/cip-052.md
+++ b/cips/cip-052.md
@@ -1,0 +1,73 @@
+| cip            | 52                                                                                             |
+|----------------|------------------------------------------------------------------------------------------------|
+| title          | v10 Network Upgrade                                                                            |
+| description    | Reference CIPs, protocol changes, and dependency upgrades included in the v10 Network Upgrade  |
+| author         | [@rach-id](https://github.com/rach-id)                                                         |
+| status         | Draft                                                                                          |
+| type           | Meta                                                                                           |
+| created        | 2026-08-13                                                                                     |
+| requires       | [CIP-45](./cip-045.md), [CIP-46](./cip-046.md), [CIP-51](./cip-051.md)                         |
+
+## Abstract
+
+This Meta CIP lists the protocol changes included in the v10 network upgrade for Celestia Mainnet Beta. The primary change is [CIP-51](./cip-051.md), which introduces Fibre for validator-operated off-chain blob availability. The upgrade also includes consensus-affecting fixes, changes to the forwarding and ZK ISM modules, and upgrades to the celestia-core, cosmos-sdk, and go-square dependencies.
+
+## Specification
+
+### Included CIPs
+
+- [CIP-51](./cip-051.md): Fibre Protocol
+
+CIP-51 is state breaking and thus requires a breaking network upgrade.
+
+### Module changes
+
+v10 includes the following consensus-affecting changes to existing modules:
+
+- Forwarding ([CIP-45](./cip-045.md)): custom IGP hooks for forwarded transfers ([celestia-app#7526](https://github.com/celestiaorg/celestia-app/pull/7526)); forwarding addresses with a custom hook bind the hook id and metadata into their derivation ([celestia-app#7643](https://github.com/celestiaorg/celestia-app/pull/7643)).
+- ZK ISM ([CIP-46](./cip-046.md)): support for SP1 v6 Groth16 proofs ([celestia-app#7374](https://github.com/celestiaorg/celestia-app/pull/7374)).
+
+### Dependency upgrades
+
+The v10 release upgrades the consensus-critical dependencies:
+
+- [celestia-core](https://github.com/celestiaorg/celestia-core): updated to a release cut from main. Notable changes include blockstore compaction after pruning, the CAT mempool SeenTx tracker, and the wire-level signature-count validation.
+- [cosmos-sdk](https://github.com/celestiaorg/cosmos-sdk): updated to v0.52.10. Notable changes include preventing updates to block `MaxGas` and running ante handlers before message execution.
+- [go-square](https://github.com/celestiaorg/go-square): updated to v4. It adds the Fibre blob encoding and related changes.
+
+### Parameter initialization
+
+The v10 upgrade handler adds the `x/fibre` and `x/valaddr` stores and runs module migrations. The migrations initialize the new `x/fibre` module with its default parameters. The upgrade handler does not set parameter values explicitly. The following values apply from the upgrade height:
+
+| Parameter                          | v10 value | Description                                                                         |
+|------------------------------------|-----------|-------------------------------------------------------------------------------------|
+| `consensus.Version.AppVersion`     | 10        | Application version used to determine protocol rules for a given height             |
+| `fibre.WithdrawalDelay`            | 24h       | Delay before escrow withdrawals become executable                                   |
+| `fibre.PaymentPromiseTimeout`      | 1h        | Time after which a payment promise can be settled by timeout                        |
+| `fibre.PaymentPromiseHeightWindow` | 1000      | Maximum normal payment-promise height lag behind current height                     |
+| `fibre.ShardRetention`             | 4h        | Minimum local duration validators keep uploaded shards                              |
+| `fibre.FullStakeStorageBudget`     | 2 Tib     | Caps the Fibre disk usage of a full-stake validator over one shard-retention window |
+
+The `x/fibre` parameter definitions and the hardcoded Fibre constants are specified in [CIP-51](./cip-051.md).
+
+## Rationale
+
+This CIP provides a complete list of the CIPs, protocol changes, and dependency upgrades included in the v10 network upgrade.
+
+## Backwards Compatibility
+
+This upgrade is not backwards compatible. Consensus nodes must upgrade to a v10-compatible `celestia-app` release before the activation height. Nodes that continue running older software will not follow the post-upgrade chain.
+
+Forwarding addresses that specify a custom hook use a new derivation scheme. Addresses without a custom hook are unchanged.
+
+## Reference Implementation
+
+The reference implementation is the celestia-app v10 release, cut from [celestia-app main](https://github.com/celestiaorg/celestia-app).
+
+## Security Considerations
+
+This CIP does not have additional security concerns beyond those discussed in CIP-45, CIP-46, and CIP-51. The namespace validation and forwarding address derivation changes remove attack surface identified before the release.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://github.com/celestiaorg/CIPs/blob/main/LICENSE).


### PR DESCRIPTION
Adds CIP-52, the v10 network upgrade Meta CIP. It lists CIP-51 (Fibre), the forwarding and ZK ISM module changes, the dependency upgrades, and the parameters initialized at the upgrade height.

closes PROTOCO-2036

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/cips/pull/401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->